### PR TITLE
[FE] 댓글, 후원 페이지 작업

### DIFF
--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -18,8 +18,11 @@ const Comment = ({ boardId, boardNum }) => {
   const [page, setPage] = useState(1);
   const [totalComments, setTotalComments] = useState(0);
 
+  const commentCountRef = React.useRef(null);
   const handleChangePage = (event, value) => {
     setPage(value);
+    commentCountRef.current.scrollIntoView(); //페이지클릭 시 스크롤 이동
+    window.scrollBy(0, -100); //헤더때문에 가려져서 -100만큼 추가 이동.
   };
 
   const encodedInputValue = inputValue
@@ -129,12 +132,6 @@ const Comment = ({ boardId, boardNum }) => {
         (a, b) => a.commentNum - b.commentNum
       );
       setComments(updatedComments);
-
-      // // 페이지에 댓글이 10개를 넘으면 다음 페이지로 이동
-      // if (updatedComments.length > itemsPerPage) {
-      //   setPage(page + 1);
-      // }
-
       setTotalComments(totalComments + 1);
 
       const lastPage = Math.ceil(updatedComments.length / itemsPerPage);
@@ -276,7 +273,7 @@ const Comment = ({ boardId, boardNum }) => {
   );
 
   return (
-    <S.CommentWrapper>
+    <S.CommentWrapper ref={commentCountRef}>
       <S.CommentCount> 💬 {totalComments}개의 댓글</S.CommentCount>
       <S.CommentList>
         {displayComments.map((comment, index) => {
@@ -362,11 +359,11 @@ const Comment = ({ boardId, boardNum }) => {
                   )}
                 {comment.memberNum === userNum && ( //댓글 작성자와 현재 로그인한 사용자가 같을 경우에만 표시
                   <>
-                    <S.ReplyButton
+                    <S.UpdateButton
                       onClick={() => handleEditClick(comment.commentNum)}
                     >
                       수정
-                    </S.ReplyButton>
+                    </S.UpdateButton>
                     <S.ReplyButtonSpace />
                     <S.DeleteButton
                       onClick={() => handleDeleteClick(comment.commentNum)}

--- a/src/components/Comment/Comment.styled.js
+++ b/src/components/Comment/Comment.styled.js
@@ -134,6 +134,20 @@ export const ReplyButton = styled(Button)`
   }
 `;
 
+export const UpdateButton = styled(Button)`
+  && {
+    color: #fff;
+    background-color: #bfbfbf;
+    width: auto;
+    height: 30px;
+    margin-left: auto;
+    margin-top: 8px;
+    &:hover {
+      background-color: #7f7f7f;
+    }
+  }
+`;
+
 export const DeleteButton = styled(Button)`
   && {
     color: #fff;
@@ -188,6 +202,7 @@ export const EditButton = styled(ReplyButton)``;
 export const CommentContentWrapper = styled.div`
   margin-top: 10px;
   margin-left: 20px;
+  min-height: 50px;
 `;
 
 export const SecretWrapper = styled.div`

--- a/src/components/Support/Volunteer/VolunteerCard.js
+++ b/src/components/Support/Volunteer/VolunteerCard.js
@@ -31,8 +31,8 @@ const VolunteerCard = ({
             style={{ textDecoration: "none", color: "inherit", width: "100%" }}
           >
             <S.Thumbnail src={imgThumbnail} alt="thumbnail" />
-            <S.User>{shelterName}</S.User>
             <S.Title>{volunteerSubject}</S.Title>
+            <S.User>{shelterName}</S.User>
             <S.Date>{formatDate(volunteerDate)}</S.Date>
             <S.CountWrapper>
               <S.Count>조회수 : {volunteerCount} </S.Count>
@@ -46,8 +46,8 @@ const VolunteerCard = ({
             style={{ textDecoration: "none", color: "inherit", width: "100%" }}
           >
             <S.Thumbnail src={imgThumbnail} alt="thumbnail" />
-            <S.User>{shelterName}</S.User>
             <S.Title>{volunteerSubject}</S.Title>
+            <S.User>{shelterName}</S.User>
             <S.Date>{formatDate(volunteerDate)}</S.Date>
             <S.CountWrapper>
               <S.Count>조회수 : {volunteerCount} </S.Count>

--- a/src/components/Support/Volunteer/VolunteerCard.styled.js
+++ b/src/components/Support/Volunteer/VolunteerCard.styled.js
@@ -18,17 +18,18 @@ export const Thumbnail = styled.img`
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
+  border: 1px solid #ccc;
 `;
 
-export const User = styled.h3`
+export const User = styled.h4`
+  font-size: 0.9rem;
+  margin: 0.5rem 0;
+`;
+
+export const Title = styled.h3`
   font-size: 1rem;
   font-weight: bold;
   margin: 1rem 0;
-`;
-
-export const Title = styled.h4`
-  font-size: 0.9rem;
-  margin: 0.5rem 0;
 `;
 
 export const Date = styled.p`

--- a/src/components/Support/Volunteer/VolunteerReviewCard.js
+++ b/src/components/Support/Volunteer/VolunteerReviewCard.js
@@ -16,10 +16,10 @@ function formatDate(dateString) {
 const VolunteerReviewCard = ({
   boardNum,
   imgThumbnail,
-  memberNum,
   reviewSubject,
   reviewDate,
   reviewCount,
+  memberNickname,
 }) => {
   return (
     <S.Container>
@@ -28,8 +28,8 @@ const VolunteerReviewCard = ({
         style={{ textDecoration: "none", color: "inherit", width: "100%" }}
       >
         <S.Thumbnail src={imgThumbnail} alt="thumbnail" />
-        <S.User>{reviewSubject}</S.User>
-        <S.Title>아이디: {memberNum}</S.Title>
+        <S.Title>{reviewSubject}</S.Title>
+        <S.User>{memberNickname}</S.User>
         <S.Date>{formatDate(reviewDate)}</S.Date>
         <S.CountWrapper>
           <S.Count>조회수 : {reviewCount} </S.Count>

--- a/src/pages/Support/Donate.js
+++ b/src/pages/Support/Donate.js
@@ -1,3 +1,89 @@
+// import React, { useState, useEffect } from "react";
+// import * as S from "./Donate.styled";
+// import VolunteerActivismOutlinedIcon from "@mui/icons-material/VolunteerActivismOutlined";
+// import axios from "axios";
+
+// const Donate = () => {
+//   const formatDate = (dateString) => {
+//     const date = new Date(dateString);
+//     const year = date.getFullYear();
+//     const month = String(date.getMonth() + 1).padStart(2, "0");
+//     const day = String(date.getDate()).padStart(2, "0");
+//     return `${year}.${month}.${day}`;
+//   };
+
+//   const [donaions, setDonations] = useState([]);
+//   const [totalCost, setTotalCost] = useState(0);
+
+//   useEffect(() => {
+//     axios
+//       .get("/donate")
+//       .then((response) => {
+//         setDonations(response.data);
+
+//         const total = response.data.reduce(
+//           //총 기부금액 계산
+//           (sum, donation) => sum + donation.donationCost,
+//           0
+//         );
+//         setTotalCost(total);
+//       })
+//       .catch((error) => {
+//         console.error("axios 오류 : ", error);
+//       });
+//   }, []);
+
+//   const leftDonations = donaions.slice(0, 5); //좌측 기부내역 표시
+//   const rightDonations = donaions.slice(5, 10); //우측 기부내역 표시
+
+//   const formatCurrency = (number) => {
+//     //3번째 자릿수 마다 ',' 와 마지막에 '원' 붙혀주는 함수
+//     return number.toLocaleString("ko-KR", { currency: "KRW" }) + "원";
+//   };
+
+//   return (
+//     <S.Container>
+//       <S.Banner>
+//         <S.DonateButton to="/donate/apply">기부하기</S.DonateButton>
+//       </S.Banner>
+//       <S.TotalDonation>
+//         누적 기부금 : {formatCurrency(totalCost)}
+//       </S.TotalDonation>
+//       <S.RecentDonations>
+//         <S.DonationColumn>
+//           {leftDonations.map((donation, index) => (
+//             <S.DonationItem key={index}>
+//               <span>{formatDate(donation.donationDate)}</span>{" "}
+//               {donation.donationName}님{" "}
+//               <span>{formatCurrency(donation.donationCost)}</span>
+//             </S.DonationItem>
+//           ))}
+//         </S.DonationColumn>
+//         <S.DonationColumn>
+//           {rightDonations.map((donation, index) => (
+//             <S.DonationItem key={index}>
+//               <span>{formatDate(donation.donationDate)}</span>{" "}
+//               {donation.donationName}님{" "}
+//               <span>{formatCurrency(donation.donationCost)}</span>
+//             </S.DonationItem>
+//           ))}
+//         </S.DonationColumn>
+//       </S.RecentDonations>
+//       <S.TransparentDisclosure>
+//         <S.IconContainer>
+//           <VolunteerActivismOutlinedIcon sx={{ width: 70, height: 70 }} />
+//         </S.IconContainer>
+//         저희 펫밀리는 <br />
+//         기부금 현황과 사용내역을
+//         <br />
+//         투명하게 공개합니다.
+//       </S.TransparentDisclosure>
+//     </S.Container>
+//   );
+// };
+
+// export default Donate;
+
 import React, { useState, useEffect } from "react";
 import * as S from "./Donate.styled";
 import VolunteerActivismOutlinedIcon from "@mui/icons-material/VolunteerActivismOutlined";
@@ -12,14 +98,22 @@ const Donate = () => {
     return `${year}.${month}.${day}`;
   };
 
-  const [donaions, setDonations] = useState([]);
+  const [memberDonaions, setMemberDonations] = useState([]); //회원 기부내역
+  const [nonMemberDonaions, setNonMemberDonations] = useState([]); //비회원 기부내역
   const [totalCost, setTotalCost] = useState(0);
 
   useEffect(() => {
     axios
       .get("/donate")
       .then((response) => {
-        setDonations(response.data);
+        const memberDonations = response.data.filter(
+          (donation) => donation.memberNum !== null
+        );
+        const nonMemberDonations = response.data.filter(
+          (donation) => donation.memberNum === null
+        );
+        setMemberDonations(memberDonations);
+        setNonMemberDonations(nonMemberDonations);
 
         const total = response.data.reduce(
           //총 기부금액 계산
@@ -33,8 +127,8 @@ const Donate = () => {
       });
   }, []);
 
-  const leftDonations = donaions.slice(0, 5); //좌측 기부내역 표시
-  const rightDonations = donaions.slice(5, 10); //우측 기부내역 표시
+  const leftDonations = nonMemberDonaions.slice(0, 10); //좌측 기부내역 표시
+  const rightDonations = memberDonaions.slice(0, 10); //우측 기부내역 표시
 
   const formatCurrency = (number) => {
     //3번째 자릿수 마다 ',' 와 마지막에 '원' 붙혀주는 함수
@@ -51,22 +145,54 @@ const Donate = () => {
       </S.TotalDonation>
       <S.RecentDonations>
         <S.DonationColumn>
-          {leftDonations.map((donation, index) => (
-            <S.DonationItem key={index}>
-              <span>{formatDate(donation.donationDate)}</span>{" "}
-              {donation.donationName}님{" "}
-              <span>{formatCurrency(donation.donationCost)}</span>
-            </S.DonationItem>
-          ))}
+          <S.TableTitle>비회원 기부 내역</S.TableTitle>
+          <S.Table>
+            <thead>
+              <S.TableRow>
+                <S.TableHeader>날짜</S.TableHeader>
+                <S.TableHeader>기부명</S.TableHeader>
+                <S.TableHeader>기부자</S.TableHeader>
+                <S.TableHeader>기부 금액</S.TableHeader>
+              </S.TableRow>
+            </thead>
+            <tbody>
+              {leftDonations.map((donation, index) => (
+                <S.TableRow key={index}>
+                  <S.TableData>{formatDate(donation.donationDate)}</S.TableData>
+                  <S.TableData>{donation.donationDonor}</S.TableData>
+                  <S.TableData>{donation.donationName}님</S.TableData>
+                  <S.TableData>
+                    {formatCurrency(donation.donationCost)}
+                  </S.TableData>
+                </S.TableRow>
+              ))}
+            </tbody>
+          </S.Table>
         </S.DonationColumn>
         <S.DonationColumn>
-          {rightDonations.map((donation, index) => (
-            <S.DonationItem key={index}>
-              <span>{formatDate(donation.donationDate)}</span>{" "}
-              {donation.donationName}님{" "}
-              <span>{formatCurrency(donation.donationCost)}</span>
-            </S.DonationItem>
-          ))}
+          <S.TableTitle>회원 기부 내역</S.TableTitle>
+          <S.Table>
+            <thead>
+              <S.TableRow>
+                <S.TableHeader>기부 날짜</S.TableHeader>
+                <S.TableHeader>기부명</S.TableHeader>
+                <S.TableHeader>기부자</S.TableHeader>
+                <S.TableHeader>기부 금액</S.TableHeader>
+              </S.TableRow>
+            </thead>
+            <tbody>
+              {rightDonations.map((donation, index) => (
+                <S.TableRow key={index}>
+                  <S.TableData>{formatDate(donation.donationDate)}</S.TableData>
+                  <S.TableData>{donation.donationDonor}</S.TableData>
+                  <S.TableData>{donation.donationName}님</S.TableData>
+                  <S.TableData>
+                    {formatCurrency(donation.donationCost)}
+                  </S.TableData>
+                </S.TableRow>
+              ))}
+            </tbody>
+          </S.Table>
         </S.DonationColumn>
       </S.RecentDonations>
       <S.TransparentDisclosure>

--- a/src/pages/Support/Donate.styled.js
+++ b/src/pages/Support/Donate.styled.js
@@ -39,6 +39,7 @@ const TotalDonation = styled.p`
 const RecentDonations = styled.div`
   display: flex;
   justify-content: space-between;
+  border-top: 1px solid #ddd;
 `;
 
 const DonationColumn = styled.div`
@@ -53,8 +54,14 @@ const DonationItem = styled.div`
   font-size: 1rem;
   padding: 10px;
   background-color: #f0f0f0;
+  flex-grow: 1;
   border-radius: 5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+const DonationItemlist = styled.div`
+margin 20px 20px 10px 10px;
+font-size : 18px;
 `;
 
 const TransparentDisclosure = styled.div`
@@ -75,6 +82,39 @@ const IconContainer = styled.div`
   align-items: center;
   margin-bottom: 1rem;
 `;
+const TableTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  margin-top: 20px;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  text-align: left;
+  border-collapse: collapse;
+`;
+
+const TableHeader = styled.th`
+  background-color: #fbd385;
+  color: #ffffff;
+  padding: 10px;
+  border: 1px solid #fbd385;
+  text-align: center;
+`;
+
+const TableRow = styled.tr`
+  :nth-child(even) {
+    background-color: #f2f2f2;
+  }
+`;
+
+const TableData = styled.td`
+  padding: 10px;
+  border: 1px solid #dddddd;
+  text-align: center;
+`;
 
 export {
   Container,
@@ -86,4 +126,10 @@ export {
   DonationItem,
   TransparentDisclosure,
   IconContainer,
+  DonationItemlist,
+  TableTitle,
+  Table,
+  TableHeader,
+  TableRow,
+  TableData,
 };

--- a/src/pages/Support/Volunteer/VolunteerNotice.js
+++ b/src/pages/Support/Volunteer/VolunteerNotice.js
@@ -8,43 +8,95 @@ import { SUPPORT } from "../../../constants/PageURL";
 import { ThemeProvider } from "@mui/material";
 import { CustomTheme } from "../../../assets/Theme/CustomTheme";
 import { AuthContext } from "../../../contexts/AuthContexts";
+import { useNavigate, useLocation } from "react-router-dom";
+import NotFound from "../../NotFound/NotFound";
 
 const VolunteerNotice = () => {
   const { loggedIn } = useContext(AuthContext);
   const [data, setData] = useState([]); // DB 데이터 가져오는 변수
   const [page, setPage] = useState(1); // 현재 페이지 관리하는 상태 변수
-  const itemsPerPage = 9; // 한페이지에 보여줄 페이지의 개수
-  const startIndex = (page - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const cards = data.slice(startIndex, endIndex); // 현재 페이지에 해당하는 카드 데이터 계산
-  const pageCount = Math.ceil(data.length / itemsPerPage); // 페이지 수 계산
+  const [pageCount, setPageCount] = useState(0); // 페이지 수 계산
+  const [validPage, setValidPage] = useState(true); //존재하는 페이지인지 확인
+
+  let navigate = useNavigate();
+  let location = useLocation();
 
   useEffect(() => {
+    // 쿼리스트링 추가
+    const params = new URLSearchParams(location.search);
+    let urlPage = Number(params.get("page"));
+
+    if (urlPage < 1 || isNaN(urlPage)) {
+      urlPage = 1;
+      params.set("page", urlPage);
+      navigate({ ...location, search: params.toString() }, { replace: true });
+      return;
+    }
+
+    const requestParams = new URLSearchParams({ page: urlPage - 1 });
+
     axios
-      .get("http://localhost:8080/board/volunteer")
+      .get(`http://localhost:8080/board/volunteer?${requestParams}`)
       .then((response) => {
-        setData(response.data);
+        const totalPages = response.data.totalPages;
+
+        if (urlPage > totalPages) {
+          setValidPage(false);
+          return;
+        }
+
+        setData(response.data.content);
+        setPageCount(totalPages);
+        setPage(urlPage);
+        setValidPage(true);
       })
       .catch((error) => {
         console.error("Error fetching data:", error);
       });
-  }, []);
+
+    window.scrollTo(0, 0); // 페이지네이션 클릭시 화면을 맨 위로 스크롤함
+  }, [location, navigate, location.search]);
 
   useEffect(() => {
-    window.scrollTo(0, 0); // 페이지네이션 클릭시 화면을 맨 위로 스크롤함
-  }, [page]);
+    const params = new URLSearchParams(location.search);
+
+    if (!params.get("page")) {
+      params.set("page", "1");
+
+      navigate(
+        {
+          ...location,
+          search: params.toString(),
+        },
+        { replace: true }
+      );
+    }
+  }, [location, navigate]);
 
   const handleChange = (event, value) => {
-    //페이지 변경 시 호출, 새 페이지의 번호를 value에 저장함.
-    setPage(value);
+    const params = new URLSearchParams(location.search);
+    params.set("page", value);
+
+    navigate(
+      {
+        ...location,
+        search: params.toString(),
+      },
+      { replace: true }
+    );
   };
+
+  if (!validPage) {
+    //존재하지 않는 페이지일 경우 NotFound 페이지 랜더링
+    return <NotFound />;
+  }
 
   return (
     <S.Container>
       <S.Title>봉사 게시판</S.Title>
       <S.CardContainer>
         <S.CardGrid>
-          {cards.map(
+          {data.map(
             (
               card //map함수로 cards에 있는 데이터 전부 보여줌.
             ) => (

--- a/src/pages/Support/Volunteer/VolunteerNotice.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerNotice.styled.js
@@ -18,7 +18,7 @@ export const Title = styled.h1`
 
 export const CardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
   width: 95%;
   max-width: 1200px;

--- a/src/pages/Support/Volunteer/VolunteerNoticeModify.js
+++ b/src/pages/Support/Volunteer/VolunteerNoticeModify.js
@@ -29,7 +29,6 @@ import Loading from "../../../components/Loading/LoadingPage";
 import { MyCustomUploadAdapterPlugin } from "../../../components/common/UploadAdapter";
 
 const VolunteerNoticeModify = () => {
-  const [post, setPost] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const { id } = useParams();
   const navigate = useNavigate();
@@ -132,7 +131,6 @@ const VolunteerNoticeModify = () => {
     try {
       const response = await axios.post("/upload", formData);
       const imageUrl = response.data;
-      // setUploadedImageUrl(imageUrl);
       return imageUrl;
     } catch (error) {
       console.error("이미지 업로드 실패 : ", error);
@@ -148,7 +146,6 @@ const VolunteerNoticeModify = () => {
           `http://localhost:8080/board/volunteer/${id}`
         ); //게시글 Detail 데이터  호출
         const data = response.data;
-        setPost(data);
         setVolunteerStartPeriod(dayjs(data.volunteerStartPeriod));
         setVolunteerEndPeriod(dayjs(data.volunteerEndPeriod));
         setTitle(data.volunteerSubject);
@@ -173,10 +170,6 @@ const VolunteerNoticeModify = () => {
     e.preventDefault();
     const isError = validate();
     if (isError) return;
-    const currentDate = new Date();
-    const isoCurrentDate = new Date(
-      currentDate.getTime() + 9 * 60 * 60 * 1000
-    ).toISOString();
     let imageUrl = Thumbnail;
 
     if (file) {
@@ -198,7 +191,6 @@ const VolunteerNoticeModify = () => {
       volunteerStatus: selectedStatus === "모집중" ? 1 : 0,
       volunteerContent: content,
       imgThumbnail: imageUrl,
-      // volunteerDate: isoCurrentDate,
     };
 
     try {
@@ -558,7 +550,7 @@ const VolunteerNoticeModify = () => {
             aria-describedby="modal-modal-description"
           >
             <Alert sx={modalStyle} severity="success">
-              작성 완료!
+              수정 완료!
             </Alert>
           </Modal>
         </ThemeProvider>

--- a/src/pages/Support/Volunteer/VolunteerReview.js
+++ b/src/pages/Support/Volunteer/VolunteerReview.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link } from "react-router-dom";
 import * as S from "./VolunteerReview.styled";
 import VolunteerReviewCard from "../../../components/Support/Volunteer/VolunteerReviewCard";
@@ -7,41 +7,93 @@ import axios from "axios";
 import { SUPPORT } from "../../../constants/PageURL";
 import { ThemeProvider } from "@mui/material";
 import { CustomTheme } from "../../../assets/Theme/CustomTheme";
+import { AuthContext } from "../../../contexts/AuthContexts";
+import { useNavigate, useLocation } from "react-router-dom";
+import NotFound from "../../NotFound/NotFound";
 
 const VolunteerReview = () => {
+  const { loggedIn } = useContext(AuthContext);
   const [data, setData] = useState([]);
   const [page, setPage] = useState(1);
-  const itemsPerPage = 9;
-  const startIndex = (page - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const cards = data.slice(startIndex, endIndex);
-  const pageCount = Math.ceil(data.length / itemsPerPage);
+  const [pageCount, setPageCount] = useState(0); // 페이지 수 계산
+  const [validPage, setValidPage] = useState(true); //존재하는 페이지인지 확인
+
+  let navigate = useNavigate();
+  let location = useLocation();
 
   useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    let urlPage = Number(params.get("page"));
+
+    if (urlPage < 1 || isNaN(urlPage)) {
+      urlPage = 1;
+      params.set("page", urlPage);
+      navigate({ ...location, search: params.toString() }, { replace: true });
+      return;
+    }
+
+    const requestParams = new URLSearchParams({ page: urlPage - 1 });
+
     axios
-      .get("http://localhost:8080/donate/volunteer/review")
+      .get(`http://localhost:8080/donate/volunteer/review?${requestParams}`)
       .then((response) => {
-        setData(response.data);
+        const totalPages = response.data.totalPages;
+        if (urlPage > totalPages) {
+          setValidPage(false);
+          return;
+        }
+
+        setData(response.data.content);
+        setPageCount(totalPages);
+        setPage(urlPage);
+        setValidPage(true);
       })
       .catch((error) => {
         console.error("데이터 수신 오류 :", error);
       });
-  }, []);
+
+    window.scrollTo(0, 0);
+  }, [location, navigate, location.search]);
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [page]);
+    const params = new URLSearchParams(location.search);
+
+    if (!params.get("page")) {
+      params.set("page", "1");
+
+      navigate(
+        {
+          ...location,
+          search: params.toString(),
+        },
+        { replace: true }
+      );
+    }
+  }, [location, navigate]);
 
   const handleChange = (event, value) => {
-    setPage(value);
+    const params = new URLSearchParams(location.search);
+    params.set("page", value);
+
+    navigate(
+      {
+        ...location,
+        search: params.toString(),
+      },
+      { replace: true }
+    );
   };
+
+  if (!validPage) {
+    return <NotFound />;
+  }
 
   return (
     <S.Container>
       <S.Title>봉사 후기 게시판</S.Title>
       <S.CardContainer>
         <S.CardGrid>
-          {cards.map((card) => (
+          {data.map((card) => (
             <VolunteerReviewCard {...card} key={card.boardNum} />
           ))}
         </S.CardGrid>
@@ -52,11 +104,13 @@ const VolunteerReview = () => {
           page={page}
           onChange={handleChange}
         />
-        <S.ButtonContainer>
-          <Link to={SUPPORT.VOLUNTEER_REVIEW_WRITE}>
-            <S.VolunteerButton>글작성</S.VolunteerButton>
-          </Link>
-        </S.ButtonContainer>
+        {loggedIn && (
+          <S.ButtonContainer>
+            <Link to={SUPPORT.VOLUNTEER_REVIEW_WRITE}>
+              <S.VolunteerButton>글작성</S.VolunteerButton>
+            </Link>
+          </S.ButtonContainer>
+        )}
       </ThemeProvider>
     </S.Container>
   );

--- a/src/pages/Support/Volunteer/VolunteerReview.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerReview.styled.js
@@ -18,7 +18,7 @@ export const Title = styled.h1`
 
 export const CardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
   width: 95%;
   max-width: 1200px;

--- a/src/pages/Support/Volunteer/VolunteerReviewDetail.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewDetail.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import * as S from "./VolunteerReviewDetail.styled";
 import { useParams, useNavigate } from "react-router-dom";
 import { ThemeProvider } from "@mui/material";
@@ -11,6 +11,7 @@ import DOMPurify from "dompurify";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import { CustomTheme } from "../../../assets/Theme/CustomTheme";
+import { AuthContext } from "../../../contexts/AuthContexts";
 
 const formatDate = (dateString) => {
   const date = new Date(dateString);
@@ -24,6 +25,7 @@ const VolunteerReviewDetail = () => {
   const [post, setPost] = useState(null); // volunteer 데이터 객체 저장 상태값
   const [isLoading, setIsLoading] = useState(true); //로딩 상태
   const { id } = useParams(); //게시글 id
+  const { userNum } = useContext(AuthContext);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -65,7 +67,10 @@ const VolunteerReviewDetail = () => {
     if (result) {
       try {
         await axios.delete(
-          `http://localhost:8080/donate/volunteer/review/${id}`
+          `http://localhost:8080/donate/volunteer/review/${id}`,
+          {
+            withCredentials: true,
+          }
         );
         alert("게시물이 삭제되었습니다.");
         navigate(SUPPORT.VOLUNTEER_REVIEW);
@@ -88,7 +93,8 @@ const VolunteerReviewDetail = () => {
         <h2>제목 {post.reviewSubject}</h2>
       </S.DetailTop>
       <S.TopInfo>
-        <S.TopNickname>밍키맘{post.memberNum}</S.TopNickname>
+        <S.UserImg src={post.memberImg}></S.UserImg>
+        <S.TopNickname>{post.memberNickname}</S.TopNickname>
         <S.TopDate>
           <AccessTimeIcon sx={{ color: "#808080", width: 18, height: 18 }} />
           {formatDate(post.reviewDate)}
@@ -104,15 +110,17 @@ const VolunteerReviewDetail = () => {
         <div dangerouslySetInnerHTML={createMarkup(post.reviewContent)} />
       </S.DetailMiddle>
       <ThemeProvider theme={CustomTheme}>
-        <S.ButtonsContainer>
-          <S.Buttons onClick={handleEdit} variant="contained">
-            수정
-          </S.Buttons>
-          <S.ButtonsSpace />
-          <S.Buttons onClick={handleDelete} variant="contained">
-            삭제
-          </S.Buttons>
-        </S.ButtonsContainer>
+        {post.memberNum === userNum && (
+          <S.ButtonsContainer>
+            <S.Buttons onClick={handleEdit} variant="contained">
+              수정
+            </S.Buttons>
+            <S.ButtonsSpace />
+            <S.Buttons onClick={handleDelete} variant="contained">
+              삭제
+            </S.Buttons>
+          </S.ButtonsContainer>
+        )}
 
         <S.DetailBottom>
           <S.horizon />

--- a/src/pages/Support/Volunteer/VolunteerReviewDetail.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewDetail.styled.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Button } from "@mui/material";
+import { Button, Avatar } from "@mui/material";
 
 export const DetailContainer = styled.div`
   width: 70vw;
@@ -31,13 +31,24 @@ export const horizon = styled.hr`
 export const TopInfo = styled.div`
   display: flex;
   align-items: center;
-  height: 40px;
+  height: 50px;
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
 `;
 
+export const UserImg = styled(Avatar)`
+  && {
+    margin-right: 8px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-left: 5px;
+  }
+`;
+
 export const TopNickname = styled.div`
   font-weight: bold;
+  align-items: center;
 `;
 
 export const TopDate = styled.div`
@@ -61,6 +72,11 @@ export const DetailMiddle = styled.div`
   padding-top: 15px;
   min-height: 300px;
   min-width: 70vw;
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 `;
 
 export const DetailBottom = styled.div`

--- a/src/pages/Support/Volunteer/VolunteerReviewModify.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewModify.styled.js
@@ -46,6 +46,19 @@ export const ButtonGroup = styled.div`
   margin-bottom: 10px;
 `;
 
+export const FormRowWithError = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 16px;
+  align-items: center;
+`;
+
+export const ErrorMsg = styled.div`
+  width: 100%;
+  margin-left: 10px;
+`;
+
 export const ImageWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -96,5 +109,9 @@ export const EditorWrapper = styled.div`
   .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
     width: 700px;
     min-height: 500px;
+  }
+
+  .ck.ck-editor__editable:not(.ck-editor__nested-editable):focus {
+    border-color: #fbd385;
   }
 `;

--- a/src/pages/Support/Volunteer/VolunteerReviewWrite.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewWrite.js
@@ -1,19 +1,63 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as S from "./VolunteerNoticeWrite.styled";
-import { TextField, Typography, ThemeProvider } from "@mui/material";
+import {
+  TextField,
+  Typography,
+  ThemeProvider,
+  FormHelperText,
+  Modal,
+  Alert,
+} from "@mui/material";
 import { SUPPORT } from "../../../constants/PageURL";
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
 import { CustomTheme } from "../../../assets/Theme/CustomTheme";
+import axios from "axios";
+import { MyCustomUploadAdapterPlugin } from "../../../components/common/UploadAdapter";
 
 const VolunteerReviewWrite = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [file, setFile] = useState(null);
-  // 사진 미리보기
 
+  const modalStyle = {
+    // 모달 스타일
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: 400,
+    bgcolor: "background.paper",
+    boxShadow: 24,
+    p: 4,
+  };
+  const [openModal, setOpenModal] = useState(false); // 모달 상태
+  const handleModalClose = () => {
+    // 모달닫는 함수
+    setOpenModal(false);
+    navigate(SUPPORT.VOLUNTEER_REVIEW);
+  };
+
+  //유효성 검증
+  const [titleError, setTitleError] = useState(false);
+  const [contentError, setContentError] = useState(false);
+  const validate = () => {
+    let isError = false;
+    if (title === "") {
+      setTitleError(true);
+      isError = true;
+    }
+    if (content === "") {
+      setContentError(true);
+      isError = true;
+    }
+
+    return isError;
+  };
+
+  // 사진 미리보기
+  const [file, setFile] = useState(null);
   const [previewUrl, setPreviewUrl] = useState(null);
   const handleFileChange = (event) => {
     const selectedFile = event.target.files[0];
@@ -27,9 +71,56 @@ const VolunteerReviewWrite = () => {
     }
   };
 
-  const handleSubmit = (e) => {
+  const uploadImage = async (file) => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await axios.post("/upload", formData);
+      const imageUrl = response.data;
+      return imageUrl;
+    } catch (error) {
+      console.error("이미지 업로드 실패", error);
+      return null;
+    }
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // 전송 로직 구현
+    const isError = validate();
+    if (isError) return;
+    const currentDate = new Date();
+    const isoCurrentDate = new Date(
+      currentDate.getTime() + 9 * 60 * 60 * 1000
+    ).toISOString();
+
+    let imageUrl = "https://via.placeholder.com/150"; // 사진 안넣었을 때 이미지 (임시)
+
+    if (file) {
+      const uploadedUrl = await uploadImage(file);
+      if (uploadedUrl) {
+        imageUrl = uploadedUrl;
+      }
+    }
+
+    const postData = {
+      reviewSubject: title,
+      reviewContent: content,
+      imgThumbnail: imageUrl,
+      reviewDate: isoCurrentDate,
+    };
+
+    try {
+      await axios.post("/donate/volunteer/review/write", postData, {
+        credentials: "include",
+      });
+      setOpenModal(true);
+      setTimeout(() => {
+        handleModalClose();
+      }, 1000);
+    } catch (error) {
+      console.error("데이터 전송 실패 : ", error);
+    }
   };
 
   const handleCancel = () => {
@@ -46,15 +137,23 @@ const VolunteerReviewWrite = () => {
         <ThemeProvider theme={CustomTheme}>
           <S.FormWrapper>
             <form onSubmit={handleSubmit}>
-              <S.FormRow>
+              <S.FormRowWithError>
                 <TextField
                   label="제목"
                   value={title}
                   size="small"
                   fullWidth
-                  onChange={(e) => setTitle(e.target.value)}
+                  onChange={(e) => {
+                    setTitleError(false);
+                    setTitle(e.target.value);
+                  }}
                 />
-              </S.FormRow>
+                <S.ErrorMsg>
+                  <FormHelperText sx={{ color: "red", fontSize: "15px" }}>
+                    {titleError ? "제목을 입력해 주세요." : null}
+                  </FormHelperText>
+                </S.ErrorMsg>
+              </S.FormRowWithError>
 
               <S.FormRow>
                 <S.ImageWrapper>
@@ -78,7 +177,7 @@ const VolunteerReviewWrite = () => {
                 )}
               </S.FormRow>
 
-              <S.FormRow>
+              <S.FormRowWithError>
                 <S.EditorWrapper>
                   <CKEditor
                     editor={ClassicEditor}
@@ -86,36 +185,29 @@ const VolunteerReviewWrite = () => {
                     onChange={(event, editor) => {
                       const data = editor.getData();
                       setContent(data);
+                      setContentError(false);
                     }}
                     config={{
-                      toolbar: [
-                        "heading",
-                        "|",
-                        "bold",
-                        "italic",
-                        "link",
-                        "bulletedList",
-                        "numberedList",
-                        "|",
-                        "indent",
-                        "outdent",
-                        "|",
-                        "blockQuote",
-                        "insertTable",
-                        "mediaEmbed",
-                        "undo",
-                        "redo",
-                      ],
                       className: "WriteEditor",
                       placeholder: "내용을 입력하세요.",
+                      extraPlugins: [MyCustomUploadAdapterPlugin],
                     }}
                   />
                 </S.EditorWrapper>
-              </S.FormRow>
+                <S.ErrorMsg>
+                  <FormHelperText sx={{ color: "red", fontSize: "15px" }}>
+                    {contentError ? "내용을 입력해 주세요." : null}
+                  </FormHelperText>
+                </S.ErrorMsg>
+              </S.FormRowWithError>
 
               <S.FormRow>
                 <S.ButtonGroup>
-                  <S.WriteButton type="submit" variant="contained">
+                  <S.WriteButton
+                    type="submit"
+                    onClick={handleSubmit}
+                    variant="contained"
+                  >
                     글쓰기
                   </S.WriteButton>
                   <S.ButtonSpace />
@@ -126,6 +218,16 @@ const VolunteerReviewWrite = () => {
               </S.FormRow>
             </form>
           </S.FormWrapper>
+          <Modal
+            open={openModal}
+            onClose={handleModalClose}
+            aria-labelledby="modal-modal-title"
+            aria-describedby="modal-modal-description"
+          >
+            <Alert sx={modalStyle} severity="success">
+              작성 완료!
+            </Alert>
+          </Modal>
         </ThemeProvider>
       </S.Container>
     </>

--- a/src/pages/Support/Volunteer/VolunteerReviewWrite.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewWrite.styled.js
@@ -36,6 +36,19 @@ export const FormRow = styled.div`
   align-items: center;
 `;
 
+export const FormRowWithError = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 16px;
+  align-items: center;
+`;
+
+export const ErrorMsg = styled.div`
+  width: 100%;
+  margin-left: 10px;
+`;
+
 export const ButtonGroup = styled.div`
   font-size: 0.8rem;
   color: gray;
@@ -95,5 +108,9 @@ export const EditorWrapper = styled.div`
   .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
     min-height: 500px;
     width: 700px;
+  }
+
+  .ck.ck-editor__editable:not(.ck-editor__nested-editable):focus {
+    border-color: #fbd385;
   }
 `;


### PR DESCRIPTION
# 댓글 컴포넌트, 후원 페이지 작업 내역
## 댓글 컴포넌트
- [x] 로그인 검증 기능 추가 : 비회원 댓글 작성 불가, 댓글 작성한 회원만 수정,삭제 가능
- [x] 페이지네이션 클릭 시 상단 이동 기능 추가
- [x] 수정 버튼 색상 변경

## 후원 페이지
- [x] 봉사 게시판, 봉사 후기 게시판 한줄에 표시되는 게시글 카드 3개 → 4개로 변경
- [x] 봉사 게시판, 봉사 후기 게시판 백엔드 페이지네이션 연동 및 쿼리스트링 추가
- [x] 봉사 게시판 보호소명, 글 제목 위치 변경, 봉사 후기 게시판 userNum 표시 → userNickname 표시로 변경
- [x] 봉사 게시판 수정 사용하지 않는 states 변수 제거
- [x] 봉사 후기 게시판 상세페이지 userImg, userNickname 표시 가능하게 디자인 수정
- [x] 봉사 후기 게시판 게시글 작성 (CKEditor 이미지 업로드, 안내 모달, 유효성 검사 기능 추가)
- [x] 봉사 후기 게시판 게시글  수정 (CKEditor 이미지 업로드, 안내 모달, 유효성 검사 기능 추가)
- [x] 봉사 후기 게시판 게시글 삭제 백엔드 연동

## 기부 페이지
- [x] 기부내역 회원,비회원 리스트 조회 기능 추가 및 디자인 수정

