### PR TITLE
[FE] 후원, 관리자 페이지 작업

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -326,6 +326,10 @@ const Router = () => {
               path={BROWSER_PATH.ADMIN.QNA}
               element={<Page.Admin.AdminQnA />}
             />
+            <Route
+              path={BROWSER_PATH.ADMIN.DONATION}
+              element={<Page.Admin.AdminDonation />}
+            />
           </Route>
         </Routes>
       </React.Suspense>

--- a/src/constants/PageURL.js
+++ b/src/constants/PageURL.js
@@ -628,5 +628,11 @@ export const ADMIN = {
   /**게시글 관리 페이지 URL
    * @return "/a/board"
    */
+
+  DONATION: "/a/donation",
+
+  /**기부 관리 페이지 URL
+   * @return "/a/donation"
+   */
   BOARD: "/a/board",
 };

--- a/src/pages/Admin/AdminNav.js
+++ b/src/pages/Admin/AdminNav.js
@@ -11,6 +11,7 @@ import NoteAltIcon from "@mui/icons-material/NoteAlt";
 import HelpCenterIcon from "@mui/icons-material/HelpCenter";
 import PetsIcon from "@mui/icons-material/Pets";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
+import VolunteerActivismOutlinedIcon from "@mui/icons-material/VolunteerActivismOutlined";
 import { ADMIN } from "../../constants/PageURL";
 import { Link } from "react-router-dom";
 
@@ -77,6 +78,17 @@ export const mainListItems = (
           <HelpCenterIcon />
         </ListItemIcon>
         <ListItemText primary="1:1문의" />
+      </ListItemButton>
+    </Link>
+    <Link
+      to={ADMIN.DONATION}
+      style={{ textDecoration: "none", color: "black" }}
+    >
+      <ListItemButton>
+        <ListItemIcon>
+          <VolunteerActivismOutlinedIcon />
+        </ListItemIcon>
+        <ListItemText primary="기부관리" />
       </ListItemButton>
     </Link>
   </React.Fragment>

--- a/src/pages/Admin/Dashboard/AdminDashBoard.js
+++ b/src/pages/Admin/Dashboard/AdminDashBoard.js
@@ -6,6 +6,8 @@ import Paper from "@mui/material/Paper";
 import Chart from "./Chart";
 import Deposits from "./Deposits";
 import Orders from "./Orders";
+import Member from "./Member";
+import DonationChart from "./DonationChart";
 
 const defaultTheme = createTheme();
 
@@ -44,6 +46,23 @@ export default function AdminDashboard() {
           <Grid item xs={12}>
             <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
               <Orders />
+            </Paper>
+          </Grid>
+          <Grid item xs={12}>
+            <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
+              <Member />
+            </Paper>
+          </Grid>
+          <Grid item xs={12}>
+            <Paper
+              sx={{
+                p: 2,
+                display: "flex",
+                flexDirection: "column",
+                height: 1000,
+              }}
+            >
+              <DonationChart />
             </Paper>
           </Grid>
         </Grid>

--- a/src/pages/Admin/Dashboard/AdminDashBoard.js
+++ b/src/pages/Admin/Dashboard/AdminDashBoard.js
@@ -3,7 +3,7 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
-import Chart from "./Chart";
+import OrderChart from "./OrderChart";
 import Deposits from "./Deposits";
 import Orders from "./Orders";
 import Member from "./Member";
@@ -23,10 +23,10 @@ export default function AdminDashboard() {
                 p: 2,
                 display: "flex",
                 flexDirection: "column",
-                height: 240,
+                height: 600,
               }}
             >
-              <Chart />
+              <OrderChart />
             </Paper>
           </Grid>
           {/* Recent Deposits */}
@@ -43,11 +43,11 @@ export default function AdminDashboard() {
             </Paper>
           </Grid>
           {/* Recent Orders */}
-          <Grid item xs={12}>
+          {/* <Grid item xs={12}>
             <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
               <Orders />
             </Paper>
-          </Grid>
+          </Grid> */}
           <Grid item xs={12}>
             <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
               <Member />

--- a/src/pages/Admin/Dashboard/DonationChart.js
+++ b/src/pages/Admin/Dashboard/DonationChart.js
@@ -1,0 +1,350 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Label,
+  ResponsiveContainer,
+  Legend,
+  BarChart,
+  Bar,
+  ReferenceLine,
+  Tooltip,
+} from "recharts";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Typography from "@mui/material/Typography";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import { ADMIN } from "../../../constants/PageURL";
+import { Link } from "react-router-dom";
+const MAX_DISPLAYED_DAILY_DATA = 31;
+
+// const data = [
+//   { date: "2023-05-01", total: 50000, member: 30000, nonMember: 20000 },
+//   { date: "2023-05-02", total: 70000, member: 40000, nonMember: 30000 },
+//   { date: "2023-05-03", total: 0, member: 0, nonMember: 0 },
+//   { date: "2023-05-04", total: 110000, member: 60000, nonMember: 50000 },
+//   { date: "2023-05-05", total: 130000, member: 70000, nonMember: 60000 },
+//   //   { date: "2023-05-06", total: 150000, member: 80000, nonMember: 70000 },
+//   //   { date: "2023-05-07", total: 170000, member: 90000, nonMember: 80000 },
+//   //   { date: "2023-05-08", total: 190000, member: 100000, nonMember: 90000 },
+//   //   { date: "2023-05-09", total: 210000, member: 110000, nonMember: 100000 },
+//   //   { date: "2023-05-10", total: 230000, member: 120000, nonMember: 110000 },
+//   //   { date: "2023-05-11", total: 250000, member: 130000, nonMember: 120000 },
+//   //   { date: "2023-05-12", total: 270000, member: 140000, nonMember: 130000 },
+//   //   { date: "2023-05-13", total: 290000, member: 150000, nonMember: 140000 },
+//   //   { date: "2023-05-14", total: 310000, member: 160000, nonMember: 150000 },
+//   //   { date: "2023-05-15", total: 330000, member: 170000, nonMember: 160000 },
+//   //   { date: "2023-05-16", total: 350000, member: 180000, nonMember: 170000 },
+//   //   { date: "2023-05-17", total: 370000, member: 190000, nonMember: 180000 },
+//   //   { date: "2023-05-18", total: 390000, member: 200000, nonMember: 190000 },
+//   //   { date: "2023-05-19", total: 410000, member: 210000, nonMember: 200000 },
+//   //   { date: "2023-05-20", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-21", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-22", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-23", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-24", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-25", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-26", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-27", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-28", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-29", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-30", total: 50000, member: 20000, nonMember: 30000 },
+//   //   { date: "2023-05-31", total: 50000, member: 20000, nonMember: 30000 },
+// ];
+
+const groupByMonth = (data) => {
+  const groupedData = data.reduce((result, item) => {
+    const [year, month] = item.date.split("-");
+    const key = `${year}-${month}`;
+
+    if (!result[key]) {
+      result[key] = {
+        date: key,
+        total: 0,
+        member: 0,
+        nonMember: 0,
+      };
+    }
+
+    result[key].total += item.total;
+    result[key].member += item.member;
+    result[key].nonMember += item.nonMember;
+
+    return result;
+  }, {});
+
+  return Object.values(groupedData);
+};
+
+const groupByMonthAndDay = (data) => {
+  return data.reduce((result, item) => {
+    const [year, month, day] = item.date.split("-");
+    const key = `${year}-${month}`;
+
+    if (!result[key]) {
+      result[key] = [];
+    }
+
+    result[key].push({
+      date: day,
+      total: item.total,
+      member: item.member,
+      nonMember: item.nonMember,
+    });
+
+    return result;
+  }, {});
+};
+
+const groupByYear = (data) => {
+  const groupedData = data.reduce((result, item) => {
+    const year = item.date.split("-")[0];
+
+    if (!result[year]) {
+      result[year] = {
+        date: year,
+        total: 0,
+        member: 0,
+        nonMember: 0,
+      };
+    }
+
+    result[year].total += item.total;
+    result[year].member += item.member;
+    result[year].nonMember += item.nonMember;
+
+    return result;
+  }, {});
+
+  return Object.values(groupedData);
+};
+
+const displayDataByMonth = (groupedDataByMonthAndDay, selectedMonth) => {
+  const monthlyData = groupedDataByMonthAndDay[selectedMonth] || [];
+  return truncateDailyData(monthlyData);
+};
+
+const truncateDailyData = (data) => {
+  if (data.length > MAX_DISPLAYED_DAILY_DATA) {
+    const interval = Math.ceil(data.length / MAX_DISPLAYED_DAILY_DATA);
+    const truncatedData = data.filter((_, index) => index % interval === 0);
+    return truncatedData;
+  }
+  return data;
+};
+
+const DonationChart = () => {
+  const [chartType, setChartType] = useState("total");
+  const [dataGroup, setDataGroup] = useState("daily");
+  const [donationsData, setDonationsData] = useState([]);
+  const [selectedMonth, setSelectedMonth] = useState("");
+
+  useEffect(() => {
+    const fetchDonationsData = async () => {
+      const response = await axios.get("/donate/Asc");
+      const fetchedData = response.data;
+
+      const processedData = fetchedData.reduce((acc, donation) => {
+        const donationDate = donation.donationDate.split("T")[0];
+        const donationCost = donation.donationCost;
+        const memberNum = donation.memberNum;
+
+        if (!acc[donationDate]) {
+          acc[donationDate] = {
+            date: donationDate,
+            total: 0,
+            member: 0,
+            nonMember: 0,
+          };
+        }
+
+        acc[donationDate].total += donationCost;
+        if (memberNum === null) {
+          acc[donationDate].nonMember += donationCost;
+        } else {
+          acc[donationDate].member += donationCost;
+        }
+
+        return acc;
+      }, {});
+
+      const processedDataArray = Object.values(processedData);
+      setDonationsData(processedDataArray);
+      const groupedDataByMonthAndDay = groupByMonthAndDay(processedDataArray);
+      setSelectedMonth(Object.keys(groupedDataByMonthAndDay)[0]);
+      setDonationsData(processedDataArray);
+    };
+
+    fetchDonationsData();
+  }, []);
+
+  const handleChartTypeChange = (event, newChartType) => {
+    if (newChartType !== null) {
+      setChartType(newChartType);
+    }
+  };
+
+  const handleDataGroupChange = (event, newDataGroup) => {
+    if (newDataGroup !== null) {
+      setDataGroup(newDataGroup);
+    }
+  };
+
+  const handleMonthChange = (event, newSelectedMonth) => {
+    if (newSelectedMonth !== null) {
+      setSelectedMonth(event.target.value);
+    }
+  };
+
+  const getChartData = () => {
+    if (dataGroup === "daily") {
+      const groupedDataByMonthAndDay = groupByMonthAndDay(donationsData);
+      return displayDataByMonth(groupedDataByMonthAndDay, selectedMonth);
+    } else if (dataGroup === "monthly") {
+      return groupByMonth(donationsData);
+    } else if (dataGroup === "yearly") {
+      return groupByYear(donationsData);
+    }
+  };
+
+  const renderTooltipContent = (props) => {
+    const { payload, label } = props;
+
+    if (payload && payload.length) {
+      const value = payload[0].value;
+      let tooltipValue = `${value.toLocaleString()}원`;
+
+      if (chartType === "total") {
+        tooltipValue = `${tooltipValue} (전체)`;
+      } else if (chartType === "member") {
+        tooltipValue = `${tooltipValue} (회원)`;
+      } else if (chartType === "nonMember") {
+        tooltipValue = `${tooltipValue} (비회원)`;
+      }
+
+      return (
+        <div
+          className="custom-tooltip"
+          style={{
+            backgroundColor: "#fff",
+            padding: "8px",
+            borderRadius: "4px",
+            border: "1px solid #ccc",
+          }}
+        >
+          <p className="label">{`${label}`}</p>
+          <p className="value">{tooltipValue}</p>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div>
+      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+        기부 통계
+      </Typography>
+      <ToggleButtonGroup
+        value={chartType}
+        exclusive
+        onChange={handleChartTypeChange}
+        aria-label="Chart Type"
+        style={{ marginBottom: "16px" }}
+      >
+        <ToggleButton value="total" aria-label="Total">
+          전체
+        </ToggleButton>
+        <ToggleButton value="member" aria-label="Member">
+          회원
+        </ToggleButton>
+        <ToggleButton value="nonMember" aria-label="Non-member">
+          비회원
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <div>
+        <ToggleButtonGroup
+          value={dataGroup}
+          exclusive
+          onChange={handleDataGroupChange}
+          aria-label="Data Group"
+          style={{ marginBottom: "16px" }}
+        >
+          <ToggleButton value="daily" aria-label="Daily">
+            일별
+          </ToggleButton>
+          <ToggleButton value="monthly" aria-label="Monthly">
+            월별
+          </ToggleButton>
+          <ToggleButton value="yearly" aria-label="Yearly">
+            년별
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </div>
+      <div>
+        {dataGroup === "daily" && (
+          <Select
+            value={selectedMonth}
+            onChange={handleMonthChange}
+            style={{ marginLeft: "16px" }}
+          >
+            {Object.keys(groupByMonthAndDay(donationsData)).map((month) => (
+              <MenuItem key={month} value={month}>
+                {month}
+              </MenuItem>
+            ))}
+          </Select>
+        )}
+      </div>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart
+          data={getChartData()}
+          margin={{ top: 16, right: 16, bottom: 0, left: 24 }}
+        >
+          <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+          <YAxis
+            tickFormatter={(value) => `${value.toLocaleString()}원`}
+            allowDecimals={false}
+            tick={{ fontSize: 12 }}
+          />
+          <Legend />
+          <Tooltip content={renderTooltipContent} />
+          <Line
+            type="monotone"
+            dataKey={chartType}
+            stroke="#fbd385"
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <div style={{ marginTop: "80px" }} />
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart
+          data={getChartData()}
+          margin={{ top: 16, right: 16, bottom: 0, left: 24 }}
+        >
+          <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+          <YAxis
+            tickFormatter={(value) => `${value.toLocaleString()}원`}
+            allowDecimals={false}
+            tick={{ fontSize: 12 }}
+          />
+          <Legend />
+          <Tooltip content={renderTooltipContent} />
+          <Bar dataKey={chartType} fill="#fbd385" />
+          <ReferenceLine y={0} stroke="#000" />
+        </BarChart>
+      </ResponsiveContainer>
+      <div style={{ textAlign: "right", marginTop: "30px" }}>
+        <Link to={ADMIN.DONATION}>기부 내역 보기</Link>
+      </div>
+    </div>
+  );
+};
+
+export default DonationChart;

--- a/src/pages/Admin/Dashboard/Member.js
+++ b/src/pages/Admin/Dashboard/Member.js
@@ -1,0 +1,151 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import { Avatar } from "@mui/material";
+import styled from "styled-components";
+import { ADMIN } from "../../../constants/PageURL";
+
+// Generate Order Data
+function createData(
+  memberNum,
+  memberId,
+  memberNickName,
+  memberEmail,
+  memberName,
+  memberGender,
+  memberBirth,
+  memberRole,
+  memberImg
+) {
+  return {
+    memberNum,
+    memberId,
+    memberNickName,
+    memberEmail,
+    memberName,
+    memberGender,
+    memberBirth,
+    memberRole,
+    memberImg,
+  };
+}
+
+const UserImg = styled(Avatar)`
+  && {
+    margin-right: 8px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-left: 10px;
+  }
+`;
+
+const rows = [
+  createData(
+    1,
+    "admin1234",
+    "관리자",
+    "admin1@test.com",
+    "관리자",
+    "male",
+    "2000-01-01",
+    "Admin",
+    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/8f230276-3448-4a42-b3fa-8bac6dc06e83.png"
+  ),
+  createData(
+    2,
+    "test1234",
+    "닉네임1",
+    "test1@test.com",
+    "홍길동",
+    "male",
+    "2000-01-01",
+    "User",
+    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/5a395426-5d25-45b4-80e1-1ca846e1b5fc.png"
+  ),
+  createData(
+    3,
+    "test1235",
+    "닉네임2",
+    "test2@test.com",
+    "김길동",
+    "male",
+    "2000-01-01",
+    "User",
+    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/66336982-ecdb-44fe-9488-1d8f7a777bfa.png"
+  ),
+  createData(
+    4,
+    "test1236",
+    "닉네임3",
+    "test1@test.com",
+    "이길동",
+    "male",
+    "2000-01-01",
+    "User",
+    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/efe36b62-5e96-4c5b-8ce7-064bc0ca6f95.png"
+  ),
+  createData(
+    5,
+    "test1237",
+    "닉네임4",
+    "test1@test.com",
+    "박길동",
+    "male",
+    "2000-01-01",
+    "User",
+    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/2d014257-7fc4-4b7a-ae2e-b554d7c3f464.png"
+  ),
+];
+
+function preventDefault(event) {
+  event.preventDefault();
+}
+
+export default function Members() {
+  return (
+    <React.Fragment>
+      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+        회원
+      </Typography>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>대표이미지</TableCell>
+            <TableCell>ID</TableCell>
+            <TableCell>닉네임</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>이름</TableCell>
+            <TableCell>성별</TableCell>
+            <TableCell>생년월일</TableCell>
+            <TableCell align="right">유저 권한</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell>
+                <UserImg src={row.memberImg} />
+              </TableCell>
+              <TableCell>{row.memberId}</TableCell>
+              <TableCell>{row.memberNickName}</TableCell>
+              <TableCell>{row.memberEmail}</TableCell>
+              <TableCell>{row.memberName}</TableCell>
+              <TableCell>{row.memberGender}</TableCell>
+              <TableCell>{row.memberBirth}</TableCell>
+              <TableCell align="right">{row.memberRole}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div style={{ marginTop: "20px", textAlign: "right" }}>
+        <Link to={ADMIN.MEMBER}>회원 관리 이동</Link>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/pages/Admin/Dashboard/OrderChart.js
+++ b/src/pages/Admin/Dashboard/OrderChart.js
@@ -1,0 +1,261 @@
+import React, { useState, useEffect } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Typography from "@mui/material/Typography";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+
+const dummyData = [
+  { date: "2023-01-01", quantity: 5, cost: 15000 },
+  { date: "2023-01-01", quantity: 3, cost: 90000 },
+  { date: "2023-01-02", quantity: 8, cost: 24000 },
+  { date: "2023-01-03", quantity: 2, cost: 18000 },
+  { date: "2023-01-04", quantity: 2, cost: 18900 },
+  { date: "2023-01-05", quantity: 2, cost: 19900 },
+  { date: "2023-01-06", quantity: 2, cost: 10900 },
+  { date: "2023-01-07", quantity: 2, cost: 13900 },
+  { date: "2023-01-08", quantity: 2, cost: 11800 },
+  { date: "2023-01-09", quantity: 2, cost: 17800 },
+  { date: "2023-01-11", quantity: 2, cost: 17600 },
+  { date: "2023-01-12", quantity: 2, cost: 17600 },
+  { date: "2023-01-13", quantity: 2, cost: 17600 },
+  { date: "2023-01-14", quantity: 2, cost: 17600 },
+  { date: "2023-01-15", quantity: 2, cost: 6760 },
+  { date: "2023-01-16", quantity: 2, cost: 6760 },
+  { date: "2023-01-17", quantity: 2, cost: 6760 },
+  { date: "2023-01-18", quantity: 2, cost: 6760 },
+  { date: "2023-01-19", quantity: 2, cost: 6760 },
+  { date: "2023-01-20", quantity: 2, cost: 6760 },
+  { date: "2023-01-21", quantity: 2, cost: 6060 },
+  { date: "2023-01-22", quantity: 2, cost: 6000 },
+  { date: "2023-01-23", quantity: 2, cost: 6000 },
+  { date: "2023-01-24", quantity: 2, cost: 6000 },
+  { date: "2023-01-25", quantity: 2, cost: 6000 },
+  { date: "2023-01-26", quantity: 2, cost: 6000 },
+  { date: "2023-01-27", quantity: 2, cost: 6000 },
+  { date: "2023-01-28", quantity: 2, cost: 6000 },
+  { date: "2023-01-29", quantity: 2, cost: 6000 },
+  { date: "2023-01-30", quantity: 2, cost: 6000 },
+  { date: "2023-01-31", quantity: 2, cost: 6000 },
+  { date: "2023-02-01", quantity: 2, cost: 6000 },
+  { date: "2023-02-02", quantity: 2, cost: 6000 },
+  { date: "2023-02-03", quantity: 2, cost: 6000 },
+  { date: "2023-02-04", quantity: 2, cost: 6000 },
+  { date: "2023-02-10", quantity: 2, cost: 6000 },
+  // ...more data
+];
+
+const aggregateData = (data, period) => {
+  const aggregation = new Map();
+
+  data.forEach((item) => {
+    const date = new Date(item.date);
+    let key;
+
+    switch (period) {
+      case "day":
+        key = date.toISOString().split("T")[0];
+        break;
+      case "month":
+        key =
+          date.getFullYear().toString() +
+          "-" +
+          (date.getMonth() + 1).toString().padStart(2, "0");
+        break;
+      case "year":
+        key = date.getFullYear().toString();
+        break;
+      default:
+        throw new Error(`Invalid period: ${period}`);
+    }
+
+    const existing = aggregation.get(key);
+    if (existing) {
+      existing.quantity += item.quantity;
+      existing.cost += item.cost;
+    } else {
+      aggregation.set(key, {
+        date: key,
+        quantity: item.quantity,
+        cost: item.cost,
+      });
+    }
+  });
+
+  return Array.from(aggregation.values());
+};
+
+const OrderChart = () => {
+  const [chartType, setChartType] = useState("quantity");
+  const [period, setPeriod] = useState("day");
+  const [selectedMonth, setSelectedMonth] = useState("");
+  const [selectedData, setSelectedData] = useState([]);
+
+  const handleChartTypeChange = (event, newChartType) => {
+    if (newChartType !== null) {
+      setChartType(newChartType);
+    }
+  };
+
+  const handlePeriodChange = (event, newPeriod) => {
+    if (newPeriod !== null) {
+      setPeriod(newPeriod);
+      setSelectedMonth("");
+      setSelectedData([]);
+    }
+  };
+
+  const handleMonthChange = (event) => {
+    const selectedMonth = event.target.value;
+    setSelectedMonth(selectedMonth);
+    const filteredData = aggregateData(
+      dummyData.filter((item) => {
+        const date = new Date(item.date);
+        const year = date.getFullYear();
+        const month = date.getMonth() + 1;
+        const formattedMonth = `${year}-${month.toString().padStart(2, "0")}`;
+        return formattedMonth.startsWith(selectedMonth);
+      }),
+      period
+    );
+    setSelectedData(filteredData);
+  };
+
+  const getMonths = () => {
+    const monthsSet = new Set();
+    dummyData.forEach((item) => {
+      const date = new Date(item.date);
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      monthsSet.add(`${year}-${month.toString().padStart(2, "0")}`);
+    });
+    return Array.from(monthsSet);
+  };
+
+  const renderTooltipContent = (props) => {
+    const { payload, label } = props;
+
+    if (payload && payload.length) {
+      const value = payload[0].value;
+      let tooltipValue = `${value.toLocaleString()}`;
+
+      if (chartType === "quantity") {
+        tooltipValue = `${tooltipValue} (수량)`;
+      } else if (chartType === "cost") {
+        tooltipValue = `${tooltipValue}원 (가격)`;
+      }
+
+      return (
+        <div
+          className="custom-tooltip"
+          style={{
+            backgroundColor: "#fff",
+            padding: "8px",
+            borderRadius: "4px",
+            border: "1px solid #ccc",
+          }}
+        >
+          <p className="label">{`${label}`}</p>
+          <p className="value">{tooltipValue}</p>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  useEffect(() => {
+    const filteredData = aggregateData(dummyData, period);
+    setSelectedData(filteredData);
+  }, [period]);
+
+  return (
+    <div>
+      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+        주문 통계
+      </Typography>
+      <ToggleButtonGroup
+        value={chartType}
+        exclusive
+        onChange={handleChartTypeChange}
+        aria-label="Chart Type"
+        style={{ marginBottom: "16px" }}
+      >
+        <ToggleButton value="quantity" aria-label="Quantity">
+          수량
+        </ToggleButton>
+        <ToggleButton value="cost" aria-label="Cost">
+          가격
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <div>
+        <ToggleButtonGroup
+          value={period}
+          exclusive
+          onChange={handlePeriodChange}
+          aria-label="Period"
+          style={{ marginBottom: "16px" }}
+        >
+          <ToggleButton value="day" aria-label="Day">
+            일별
+          </ToggleButton>
+          <ToggleButton value="month" aria-label="Month">
+            월별
+          </ToggleButton>
+          <ToggleButton value="year" aria-label="Year">
+            년별
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </div>
+      {period === "day" && (
+        <div>
+          <Select
+            value={selectedMonth}
+            onChange={handleMonthChange}
+            style={{ marginLeft: "16px" }}
+          >
+            {getMonths().map((month) => (
+              <MenuItem key={month} value={month}>
+                {month}
+              </MenuItem>
+            ))}
+          </Select>
+        </div>
+      )}
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart
+          data={selectedMonth ? selectedData : aggregateData(dummyData, period)}
+          margin={{ top: 16, right: 16, bottom: 0, left: 24 }}
+        >
+          <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+          <YAxis
+            tickFormatter={(value) => `${value.toLocaleString()}`}
+            allowDecimals={false}
+            tick={{ fontSize: 12 }}
+          />
+          <Legend />
+          <Tooltip content={renderTooltipContent} />
+          <Area
+            type="monotone"
+            dataKey={chartType}
+            stroke="#fbd385"
+            fill="#fbd385"
+            fillOpacity={0.3}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+      <div style={{ marginTop: "80px" }} />
+    </div>
+  );
+};
+
+export default OrderChart;

--- a/src/pages/Admin/Donation/AdminDonation.js
+++ b/src/pages/Admin/Donation/AdminDonation.js
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import * as S from "./AdminDonation.styled";
+import LoadingPage from "../../../components/Loading/LoadingPage";
+import VolunteerPagination from "../../../components/Support/Volunteer/VolunteerPagination";
+
+const AdminDonation = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [memberDonaions, setMemberDonations] = useState({
+    content: [],
+    totalPages: 0,
+  }); //회원 기부내역
+  const [nonMemberDonaions, setNonMemberDonations] = useState({
+    content: [],
+    totalPages: 0,
+  }); //비회원 기부내역
+  const [totalCost, setTotalCost] = useState(0);
+  const [memberPage, setMemberPage] = useState(0);
+  const [nonMemberPage, setNonMemberPage] = useState(0);
+  const [size, setSize] = useState(10);
+
+  const handleMemberChange = (event, value) => {
+    setMemberPage(value - 1);
+  };
+
+  const handleNonMemberChange = (event, value) => {
+    setNonMemberPage(value - 1);
+  };
+
+  useEffect(() => {
+    Promise.all([
+      axios.get("/donate/member", {
+        params: {
+          page: memberPage,
+          size: size,
+        },
+      }),
+      axios.get("/donate/non-member", {
+        params: {
+          page: nonMemberPage,
+          size: size,
+        },
+      }),
+      axios.get("/donate/total"),
+    ])
+      .then(([memberRes, nonMemberRes, totalRes]) => {
+        setMemberDonations({
+          content: memberRes.data.content,
+          totalPages: memberRes.data.totalPages,
+        });
+        setNonMemberDonations({
+          content: nonMemberRes.data.content,
+          totalPages: nonMemberRes.data.totalPages,
+        });
+        setTotalCost(totalRes.data);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.error("axios 오류 : ", error);
+        setIsLoading(false);
+      });
+  }, [memberPage, nonMemberPage, size]);
+
+  const formatCurrency = (number) => {
+    return number.toLocaleString("ko-KR", { currency: "KRW" }) + "원";
+  };
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}`;
+  };
+
+  if (isLoading) {
+    return (
+      <div>
+        <LoadingPage />
+      </div>
+    );
+  } else {
+    return (
+      <S.Container>
+        <S.TotalDonation>
+          누적 기부금 : {formatCurrency(totalCost)}
+        </S.TotalDonation>
+        <S.RecentDonations>
+          <S.DonationColumn>
+            <S.TableTitle>비회원 기부 내역</S.TableTitle>
+            <S.Table>
+              <thead>
+                <S.TableRow>
+                  <S.TableHeader>기부날짜</S.TableHeader>
+                  <S.TableHeader>기부명</S.TableHeader>
+                  <S.TableHeader>기부자</S.TableHeader>
+                  <S.TableHeader>기부자 전화번호</S.TableHeader>
+                  <S.TableHeader>기부자 이메일</S.TableHeader>
+                  <S.TableHeader>기부 금액</S.TableHeader>
+                </S.TableRow>
+              </thead>
+              <tbody>
+                {nonMemberDonaions.content.map((donation, index) => (
+                  <S.TableRow key={index}>
+                    <S.TableData>
+                      {formatDate(donation.donationDate)}
+                    </S.TableData>
+                    <S.TableData>{donation.donationDonor}</S.TableData>
+                    <S.TableData>{donation.donationName}님</S.TableData>
+                    <S.TableData>{donation.donationTel}</S.TableData>
+                    <S.TableData>{donation.donationEmail}</S.TableData>
+                    <S.TableData>
+                      {formatCurrency(donation.donationCost)}
+                    </S.TableData>
+                  </S.TableRow>
+                ))}
+              </tbody>
+            </S.Table>
+            <VolunteerPagination
+              count={nonMemberDonaions.totalPages}
+              page={nonMemberPage + 1}
+              onChange={handleNonMemberChange}
+            />
+          </S.DonationColumn>
+        </S.RecentDonations>
+        <S.RecentDonations>
+          <S.DonationColumn>
+            <S.TableTitle>회원 기부 내역</S.TableTitle>
+            <S.Table>
+              <thead>
+                <S.TableRow>
+                  <S.TableHeader>기부날짜</S.TableHeader>
+                  <S.TableHeader>기부명</S.TableHeader>
+                  <S.TableHeader>기부자</S.TableHeader>
+                  <S.TableHeader>기부자 전화번호</S.TableHeader>
+                  <S.TableHeader>기부자 이메일</S.TableHeader>
+                  <S.TableHeader>기부 금액</S.TableHeader>
+                </S.TableRow>
+              </thead>
+              <tbody>
+                {memberDonaions.content.map((donation, index) => (
+                  <S.TableRow key={index}>
+                    <S.TableData>
+                      {formatDate(donation.donationDate)}
+                    </S.TableData>
+                    <S.TableData>{donation.donationDonor}</S.TableData>
+                    <S.TableData>{donation.donationName}님</S.TableData>
+                    <S.TableData>{donation.donationTel}</S.TableData>
+                    <S.TableData>{donation.donationEmail}</S.TableData>
+                    <S.TableData>
+                      {formatCurrency(donation.donationCost)}
+                    </S.TableData>
+                  </S.TableRow>
+                ))}
+              </tbody>
+            </S.Table>
+            <VolunteerPagination
+              count={memberDonaions.totalPages}
+              page={memberPage + 1}
+              onChange={handleMemberChange}
+            />
+          </S.DonationColumn>
+        </S.RecentDonations>
+      </S.Container>
+    );
+  }
+};
+
+export default AdminDonation;

--- a/src/pages/Admin/Donation/AdminDonation.styled.js
+++ b/src/pages/Admin/Donation/AdminDonation.styled.js
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+
+const Container = styled.div`
+  width: 80vw;
+  margin: 0 auto;
+  margin-top: 3%;
+  min-width: 1000px;
+`;
+
+const TotalDonation = styled.p`
+  text-align: right;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 20px 0;
+`;
+
+const RecentDonations = styled.div`
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid #ddd;
+`;
+
+const DonationColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  margin-bottom: 40px;
+`;
+
+const TableTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  margin-top: 20px;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  text-align: left;
+  border-collapse: collapse;
+`;
+
+const TableHeader = styled.th`
+  background-color: #fbd385;
+  //   color: #ffffff;
+  padding: 10px;
+  border: 1px solid #fbd385;
+  text-align: center;
+`;
+
+const TableRow = styled.tr`
+  :nth-child(even) {
+    background-color: #f2f2f2;
+  }
+`;
+
+const TableData = styled.td`
+  padding: 10px 5px 5px 10px;
+  border: 1px solid #dddddd;
+  text-align: center;
+`;
+
+export {
+  Container,
+  TotalDonation,
+  RecentDonations,
+  DonationColumn,
+  TableTitle,
+  Table,
+  TableHeader,
+  TableRow,
+  TableData,
+};

--- a/src/pages/ImportPages.js
+++ b/src/pages/ImportPages.js
@@ -96,6 +96,7 @@ import AdminOrder from "./Admin//Orders/AdminOrder";
 import AdminProduct from "./Admin/Products/AdminProduct";
 import AdminProductWrite from "./Admin/Products/AdminProductWrite";
 import AdminQnA from "./Admin/QnA/AdminQnA";
+import AdminDonation from "./Admin/Donation/AdminDonation";
 
 /**
  ** Layout
@@ -355,4 +356,5 @@ export const Admin = {
   AdminProduct: AdminProduct,
   AdminProductWrite: AdminProductWrite,
   AdminQnA: AdminQnA,
+  AdminDonation: AdminDonation,
 };

--- a/src/pages/Support/Donate.js
+++ b/src/pages/Support/Donate.js
@@ -1,93 +1,8 @@
-// import React, { useState, useEffect } from "react";
-// import * as S from "./Donate.styled";
-// import VolunteerActivismOutlinedIcon from "@mui/icons-material/VolunteerActivismOutlined";
-// import axios from "axios";
-
-// const Donate = () => {
-//   const formatDate = (dateString) => {
-//     const date = new Date(dateString);
-//     const year = date.getFullYear();
-//     const month = String(date.getMonth() + 1).padStart(2, "0");
-//     const day = String(date.getDate()).padStart(2, "0");
-//     return `${year}.${month}.${day}`;
-//   };
-
-//   const [donaions, setDonations] = useState([]);
-//   const [totalCost, setTotalCost] = useState(0);
-
-//   useEffect(() => {
-//     axios
-//       .get("/donate")
-//       .then((response) => {
-//         setDonations(response.data);
-
-//         const total = response.data.reduce(
-//           //총 기부금액 계산
-//           (sum, donation) => sum + donation.donationCost,
-//           0
-//         );
-//         setTotalCost(total);
-//       })
-//       .catch((error) => {
-//         console.error("axios 오류 : ", error);
-//       });
-//   }, []);
-
-//   const leftDonations = donaions.slice(0, 5); //좌측 기부내역 표시
-//   const rightDonations = donaions.slice(5, 10); //우측 기부내역 표시
-
-//   const formatCurrency = (number) => {
-//     //3번째 자릿수 마다 ',' 와 마지막에 '원' 붙혀주는 함수
-//     return number.toLocaleString("ko-KR", { currency: "KRW" }) + "원";
-//   };
-
-//   return (
-//     <S.Container>
-//       <S.Banner>
-//         <S.DonateButton to="/donate/apply">기부하기</S.DonateButton>
-//       </S.Banner>
-//       <S.TotalDonation>
-//         누적 기부금 : {formatCurrency(totalCost)}
-//       </S.TotalDonation>
-//       <S.RecentDonations>
-//         <S.DonationColumn>
-//           {leftDonations.map((donation, index) => (
-//             <S.DonationItem key={index}>
-//               <span>{formatDate(donation.donationDate)}</span>{" "}
-//               {donation.donationName}님{" "}
-//               <span>{formatCurrency(donation.donationCost)}</span>
-//             </S.DonationItem>
-//           ))}
-//         </S.DonationColumn>
-//         <S.DonationColumn>
-//           {rightDonations.map((donation, index) => (
-//             <S.DonationItem key={index}>
-//               <span>{formatDate(donation.donationDate)}</span>{" "}
-//               {donation.donationName}님{" "}
-//               <span>{formatCurrency(donation.donationCost)}</span>
-//             </S.DonationItem>
-//           ))}
-//         </S.DonationColumn>
-//       </S.RecentDonations>
-//       <S.TransparentDisclosure>
-//         <S.IconContainer>
-//           <VolunteerActivismOutlinedIcon sx={{ width: 70, height: 70 }} />
-//         </S.IconContainer>
-//         저희 펫밀리는 <br />
-//         기부금 현황과 사용내역을
-//         <br />
-//         투명하게 공개합니다.
-//       </S.TransparentDisclosure>
-//     </S.Container>
-//   );
-// };
-
-// export default Donate;
-
 import React, { useState, useEffect } from "react";
 import * as S from "./Donate.styled";
 import VolunteerActivismOutlinedIcon from "@mui/icons-material/VolunteerActivismOutlined";
 import axios from "axios";
+import LoadingPage from "../../components/Loading/LoadingPage";
 
 const Donate = () => {
   const formatDate = (dateString) => {
@@ -97,115 +12,127 @@ const Donate = () => {
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}.${month}.${day}`;
   };
-
+  const [isLoading, setIsLoading] = useState(true);
   const [memberDonaions, setMemberDonations] = useState([]); //회원 기부내역
   const [nonMemberDonaions, setNonMemberDonations] = useState([]); //비회원 기부내역
   const [totalCost, setTotalCost] = useState(0);
 
   useEffect(() => {
-    axios
-      .get("/donate")
-      .then((response) => {
-        const memberDonations = response.data.filter(
-          (donation) => donation.memberNum !== null
-        );
-        const nonMemberDonations = response.data.filter(
-          (donation) => donation.memberNum === null
-        );
-        setMemberDonations(memberDonations);
-        setNonMemberDonations(nonMemberDonations);
-
-        const total = response.data.reduce(
-          //총 기부금액 계산
-          (sum, donation) => sum + donation.donationCost,
-          0
-        );
-        setTotalCost(total);
+    Promise.all([
+      axios.get("/donate/member", {
+        params: {
+          page: 0,
+          size: 10,
+        },
+      }),
+      axios.get("/donate/non-member", {
+        params: {
+          page: 0,
+          size: 10,
+        },
+      }),
+      axios.get("/donate/total"),
+    ])
+      .then(([memberRes, nonMemberRes, totalRes]) => {
+        setMemberDonations(memberRes.data.content);
+        setNonMemberDonations(nonMemberRes.data.content);
+        setTotalCost(totalRes.data);
+        setIsLoading(false);
       })
       .catch((error) => {
         console.error("axios 오류 : ", error);
+        setIsLoading(false);
       });
   }, []);
-
-  const leftDonations = nonMemberDonaions.slice(0, 10); //좌측 기부내역 표시
-  const rightDonations = memberDonaions.slice(0, 10); //우측 기부내역 표시
 
   const formatCurrency = (number) => {
     //3번째 자릿수 마다 ',' 와 마지막에 '원' 붙혀주는 함수
     return number.toLocaleString("ko-KR", { currency: "KRW" }) + "원";
   };
 
-  return (
-    <S.Container>
-      <S.Banner>
-        <S.DonateButton to="/donate/apply">기부하기</S.DonateButton>
-      </S.Banner>
-      <S.TotalDonation>
-        누적 기부금 : {formatCurrency(totalCost)}
-      </S.TotalDonation>
-      <S.RecentDonations>
-        <S.DonationColumn>
-          <S.TableTitle>비회원 기부 내역</S.TableTitle>
-          <S.Table>
-            <thead>
-              <S.TableRow>
-                <S.TableHeader>날짜</S.TableHeader>
-                <S.TableHeader>기부명</S.TableHeader>
-                <S.TableHeader>기부자</S.TableHeader>
-                <S.TableHeader>기부 금액</S.TableHeader>
-              </S.TableRow>
-            </thead>
-            <tbody>
-              {leftDonations.map((donation, index) => (
-                <S.TableRow key={index}>
-                  <S.TableData>{formatDate(donation.donationDate)}</S.TableData>
-                  <S.TableData>{donation.donationDonor}</S.TableData>
-                  <S.TableData>{donation.donationName}님</S.TableData>
-                  <S.TableData>
-                    {formatCurrency(donation.donationCost)}
-                  </S.TableData>
+  if (isLoading) {
+    return (
+      <div>
+        <LoadingPage />
+      </div>
+    );
+  } else {
+    return (
+      <S.Container>
+        <S.Banner>
+          <S.DonateButton to="/donate/apply">기부하기</S.DonateButton>
+        </S.Banner>
+        <S.TotalDonation>
+          누적 기부금 : {formatCurrency(totalCost)}
+        </S.TotalDonation>
+        <S.RecentDonations>
+          <S.DonationColumn>
+            <S.TableTitle>비회원 기부 내역</S.TableTitle>
+            <S.Table>
+              <thead>
+                <S.TableRow>
+                  <S.TableHeader>날짜</S.TableHeader>
+                  <S.TableHeader>기부명</S.TableHeader>
+                  <S.TableHeader>기부자</S.TableHeader>
+                  <S.TableHeader>기부 금액</S.TableHeader>
                 </S.TableRow>
-              ))}
-            </tbody>
-          </S.Table>
-        </S.DonationColumn>
-        <S.DonationColumn>
-          <S.TableTitle>회원 기부 내역</S.TableTitle>
-          <S.Table>
-            <thead>
-              <S.TableRow>
-                <S.TableHeader>기부 날짜</S.TableHeader>
-                <S.TableHeader>기부명</S.TableHeader>
-                <S.TableHeader>기부자</S.TableHeader>
-                <S.TableHeader>기부 금액</S.TableHeader>
-              </S.TableRow>
-            </thead>
-            <tbody>
-              {rightDonations.map((donation, index) => (
-                <S.TableRow key={index}>
-                  <S.TableData>{formatDate(donation.donationDate)}</S.TableData>
-                  <S.TableData>{donation.donationDonor}</S.TableData>
-                  <S.TableData>{donation.donationName}님</S.TableData>
-                  <S.TableData>
-                    {formatCurrency(donation.donationCost)}
-                  </S.TableData>
+              </thead>
+              <tbody>
+                {nonMemberDonaions.map((donation, index) => (
+                  <S.TableRow key={index}>
+                    <S.TableData>
+                      {formatDate(donation.donationDate)}
+                    </S.TableData>
+                    <S.TableData>{donation.donationDonor}</S.TableData>
+                    <S.TableData>{donation.donationName}님</S.TableData>
+                    <S.TableData>
+                      {formatCurrency(donation.donationCost)}
+                    </S.TableData>
+                  </S.TableRow>
+                ))}
+              </tbody>
+            </S.Table>
+          </S.DonationColumn>
+          <S.DonationColumn>
+            <S.TableTitle>회원 기부 내역</S.TableTitle>
+            <S.Table>
+              <thead>
+                <S.TableRow>
+                  <S.TableHeader>기부 날짜</S.TableHeader>
+                  <S.TableHeader>기부명</S.TableHeader>
+                  <S.TableHeader>기부자</S.TableHeader>
+                  <S.TableHeader>기부 금액</S.TableHeader>
                 </S.TableRow>
-              ))}
-            </tbody>
-          </S.Table>
-        </S.DonationColumn>
-      </S.RecentDonations>
-      <S.TransparentDisclosure>
-        <S.IconContainer>
-          <VolunteerActivismOutlinedIcon sx={{ width: 70, height: 70 }} />
-        </S.IconContainer>
-        저희 펫밀리는 <br />
-        기부금 현황과 사용내역을
-        <br />
-        투명하게 공개합니다.
-      </S.TransparentDisclosure>
-    </S.Container>
-  );
+              </thead>
+              <tbody>
+                {memberDonaions.map((donation, index) => (
+                  <S.TableRow key={index}>
+                    <S.TableData>
+                      {formatDate(donation.donationDate)}
+                    </S.TableData>
+                    <S.TableData>{donation.donationDonor}</S.TableData>
+                    <S.TableData>{donation.donationName}님</S.TableData>
+                    <S.TableData>
+                      {formatCurrency(donation.donationCost)}
+                    </S.TableData>
+                  </S.TableRow>
+                ))}
+              </tbody>
+            </S.Table>
+          </S.DonationColumn>
+        </S.RecentDonations>
+        <S.TransparentDisclosure>
+          <S.IconContainer>
+            <VolunteerActivismOutlinedIcon sx={{ width: 70, height: 70 }} />
+          </S.IconContainer>
+          저희 펫밀리는 <br />
+          기부금 현황과 사용내역을
+          <br />
+          투명하게 공개합니다.
+        </S.TransparentDisclosure>
+      </S.Container>
+    );
+  }
 };
 
 export default Donate;

--- a/src/pages/Support/Donate.styled.js
+++ b/src/pages/Support/Donate.styled.js
@@ -111,7 +111,7 @@ const TableRow = styled.tr`
 `;
 
 const TableData = styled.td`
-  padding: 10px;
+  padding: 10px 5px 5px 10px;
   border: 1px solid #dddddd;
   text-align: center;
 `;

--- a/src/pages/Support/Volunteer/VolunteerNotice.js
+++ b/src/pages/Support/Volunteer/VolunteerNotice.js
@@ -40,7 +40,7 @@ const VolunteerNotice = () => {
       .then((response) => {
         const totalPages = response.data.totalPages;
 
-        if (urlPage > totalPages) {
+        if (totalPages !== 0 && urlPage > totalPages) {
           setValidPage(false);
           return;
         }
@@ -95,15 +95,19 @@ const VolunteerNotice = () => {
     <S.Container>
       <S.Title>봉사 게시판</S.Title>
       <S.CardContainer>
-        <S.CardGrid>
-          {data.map(
-            (
-              card //map함수로 cards에 있는 데이터 전부 보여줌.
-            ) => (
-              <VolunteerCard {...card} key={card.boardNum} />
-            )
-          )}
-        </S.CardGrid>
+        {data.length === 0 ? (
+          <S.NoDataContainer>게시글이 없습니다.</S.NoDataContainer>
+        ) : (
+          <S.CardGrid>
+            {data.map(
+              (
+                card //map함수로 cards에 있는 데이터 전부 보여줌.
+              ) => (
+                <VolunteerCard {...card} key={card.boardNum} />
+              )
+            )}
+          </S.CardGrid>
+        )}
       </S.CardContainer>
       <ThemeProvider theme={CustomTheme}>
         <VolunteerPagination
@@ -115,7 +119,7 @@ const VolunteerNotice = () => {
         {loggedIn && (
           <S.ButtonContainer>
             <Link to={SUPPORT.VOLUNTEER_NOTICE_WRITE}>
-              <S.VolunteerButton>글 작성</S.VolunteerButton>
+              <S.VolunteerButton>글쓰기</S.VolunteerButton>
             </Link>
           </S.ButtonContainer>
         )}

--- a/src/pages/Support/Volunteer/VolunteerNotice.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerNotice.styled.js
@@ -44,11 +44,27 @@ export const ButtonContainer = styled.div`
 
 export const VolunteerButton = styled(Button)`
   && {
-    color: #fff;
     background-color: #fbd385;
-    width: auto;
+    color: white;
+    width: 90px;
+    height: 30px;
+    margin-top: 10px;
+    margin-right: 10px;
+    float: right;
     &:hover {
-      background-color: #ffbe3f;
+      background-color: #facc73;
+    }
+    &:focus {
+      background-color: #facc73;
+    }
     }
   }
+`;
+
+export const NoDataContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 250px;
+  font-size: 20px;
 `;

--- a/src/pages/Support/Volunteer/VolunteerNoticeWrite.js
+++ b/src/pages/Support/Volunteer/VolunteerNoticeWrite.js
@@ -513,9 +513,9 @@ const VolunteerNoticeWrite = () => {
                     글쓰기
                   </S.WriteButton>
                   <S.ButtonSpace />
-                  <S.WriteButton onClick={handleCancel} variant="contained">
+                  <S.CancleButton onClick={handleCancel} variant="contained">
                     취소
-                  </S.WriteButton>
+                  </S.CancleButton>
                 </S.ButtonGroup>
               </S.FormRow>
             </form>

--- a/src/pages/Support/Volunteer/VolunteerNoticeWrite.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerNoticeWrite.styled.js
@@ -123,6 +123,18 @@ export const WriteButton = styled(Button)`
   }
 `;
 
+export const CancleButton = styled(Button)`
+  && {
+    color: #fff;
+    background-color: #bfbfbf;
+    width: auto;
+    margin-left: auto;
+    &:hover {
+      background-color: #7f7f7f;
+    }
+  }
+`;
+
 export const EditorWrapper = styled.div`
   .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
     min-height: 500px;

--- a/src/pages/Support/Volunteer/VolunteerReview.js
+++ b/src/pages/Support/Volunteer/VolunteerReview.js
@@ -38,7 +38,7 @@ const VolunteerReview = () => {
       .get(`http://localhost:8080/donate/volunteer/review?${requestParams}`)
       .then((response) => {
         const totalPages = response.data.totalPages;
-        if (urlPage > totalPages) {
+        if (totalPages !== 0 && urlPage > totalPages) {
           setValidPage(false);
           return;
         }
@@ -92,11 +92,15 @@ const VolunteerReview = () => {
     <S.Container>
       <S.Title>봉사 후기 게시판</S.Title>
       <S.CardContainer>
-        <S.CardGrid>
-          {data.map((card) => (
-            <VolunteerReviewCard {...card} key={card.boardNum} />
-          ))}
-        </S.CardGrid>
+        {data.length === 0 ? (
+          <S.NoDataContainer>게시글이 없습니다.</S.NoDataContainer>
+        ) : (
+          <S.CardGrid>
+            {data.map((card) => (
+              <VolunteerReviewCard {...card} key={card.boardNum} />
+            ))}
+          </S.CardGrid>
+        )}
       </S.CardContainer>
       <ThemeProvider theme={CustomTheme}>
         <VolunteerPagination
@@ -107,7 +111,7 @@ const VolunteerReview = () => {
         {loggedIn && (
           <S.ButtonContainer>
             <Link to={SUPPORT.VOLUNTEER_REVIEW_WRITE}>
-              <S.VolunteerButton>글작성</S.VolunteerButton>
+              <S.VolunteerButton>글쓰기</S.VolunteerButton>
             </Link>
           </S.ButtonContainer>
         )}

--- a/src/pages/Support/Volunteer/VolunteerReview.styled.js
+++ b/src/pages/Support/Volunteer/VolunteerReview.styled.js
@@ -44,11 +44,26 @@ export const ButtonContainer = styled.div`
 
 export const VolunteerButton = styled(Button)`
   && {
-    color: #fff;
     background-color: #fbd385;
-    width: auto;
+    color: white;
+    width: 90px;
+    height: 30px;
+    margin-top: 10px;
+    margin-right: 10px;
+    float: right;
     &:hover {
-      background-color: #ffbe3f;
+      background-color: #facc73;
+    }
+    &:focus {
+      background-color: #facc73;
     }
   }
+`;
+
+export const NoDataContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 250px;
+  font-size: 20px;
 `;

--- a/src/pages/Support/Volunteer/VolunteerReviewWrite.js
+++ b/src/pages/Support/Volunteer/VolunteerReviewWrite.js
@@ -211,9 +211,9 @@ const VolunteerReviewWrite = () => {
                     글쓰기
                   </S.WriteButton>
                   <S.ButtonSpace />
-                  <S.WriteButton onClick={handleCancel} variant="contained">
+                  <S.CancleButton onClick={handleCancel} variant="contained">
                     취소
-                  </S.WriteButton>
+                  </S.CancleButton>
                 </S.ButtonGroup>
               </S.FormRow>
             </form>


### PR DESCRIPTION
# 댓글 컴포넌트, 후원 페이지 작업 내역
## 후원 페이지
- [x] 봉사 게시판, 봉사 후기 게시판 글쓰기, 취소 버튼 색상 다른 게시판과 통일
- [x] 봉사 게시판, 봉사 후기 게시판 게시글 0개일 때 404오류 뜨는 문제 fix
- [x] 기부 내역 페이지 회원, 비회원 별 데이터 10개씩만 받아오고, 누적 기부금 백엔드에서 처리한 데이터 사용하도록 수정

## 관리자 페이지
- [x] 관리자 네비게이션에 기부 관리 항목 추가 및 URL, 라우터 설정
- [x] 관리자 기부 관리 페이지에 회원,비회원 기부 리스트, 페이지네이션 추가 (백엔드 연동 O)
- [x] 관리자 대시보드 기부 통계 차트 구현 (백엔드 연동 O)
- [x] 관리자 대시보드 회원 리스트 구현 (백엔드 연동X)
- [x] 관리자 대시보드 주문 통계 차트 구현 (백엔드 연동X)
