### PR TITLE
[FE] 관리자 페이지, 후원 페이지 작업

### DIFF
--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -359,17 +359,17 @@ const Comment = ({ boardId, boardNum }) => {
                   )}
                 {comment.memberNum === userNum && ( //댓글 작성자와 현재 로그인한 사용자가 같을 경우에만 표시
                   <>
-                    <S.UpdateButton
-                      onClick={() => handleEditClick(comment.commentNum)}
-                    >
-                      수정
-                    </S.UpdateButton>
-                    <S.ReplyButtonSpace />
                     <S.DeleteButton
                       onClick={() => handleDeleteClick(comment.commentNum)}
                     >
                       삭제
                     </S.DeleteButton>
+                    <S.ReplyButtonSpace />
+                    <S.UpdateButton
+                      onClick={() => handleEditClick(comment.commentNum)}
+                    >
+                      수정
+                    </S.UpdateButton>
                   </>
                 )}
               </S.Reply>

--- a/src/pages/Admin/Dashboard/AdminDashBoard.js
+++ b/src/pages/Admin/Dashboard/AdminDashBoard.js
@@ -5,9 +5,10 @@ import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import OrderChart from "./OrderChart";
 import Deposits from "./Deposits";
-import Orders from "./Orders";
 import Member from "./Member";
 import DonationChart from "./DonationChart";
+import Adopt from "./Adopt";
+import Board from "./Board";
 
 const defaultTheme = createTheme();
 
@@ -15,39 +16,48 @@ export default function AdminDashboard() {
   return (
     <ThemeProvider theme={defaultTheme}>
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-        <Grid container spacing={3}>
-          {/* Chart */}
+        <Grid container spacing={2}>
           <Grid item xs={12} md={8} lg={9}>
+            {/* <Grid item xs={12}> */}
             <Paper
               sx={{
                 p: 2,
                 display: "flex",
                 flexDirection: "column",
-                height: 600,
+                height: 560,
               }}
             >
               <OrderChart />
             </Paper>
           </Grid>
-          {/* Recent Deposits */}
           <Grid item xs={12} md={4} lg={3}>
             <Paper
               sx={{
                 p: 2,
                 display: "flex",
                 flexDirection: "column",
-                height: 240,
+                height: 170,
               }}
             >
               <Deposits />
             </Paper>
-          </Grid>
-          {/* Recent Orders */}
-          {/* <Grid item xs={12}>
-            <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
-              <Orders />
+            <Paper
+              sx={{
+                p: 2,
+                display: "flex",
+                flexDirection: "column",
+                height: 374,
+                mt: 2,
+              }}
+            >
+              <Adopt />
             </Paper>
-          </Grid> */}
+          </Grid>
+          <Grid item xs={12}>
+            <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
+              <Board />
+            </Paper>
+          </Grid>
           <Grid item xs={12}>
             <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
               <Member />
@@ -59,7 +69,7 @@ export default function AdminDashboard() {
                 p: 2,
                 display: "flex",
                 flexDirection: "column",
-                height: 1000,
+                height: 940,
               }}
             >
               <DonationChart />

--- a/src/pages/Admin/Dashboard/Adopt.js
+++ b/src/pages/Admin/Dashboard/Adopt.js
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import Typography from "@mui/material/Typography";
+import { ADMIN } from "../../../constants/PageURL";
+import axios from "axios";
+import Title from "./Title";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+
+const Adopt = () => {
+  const [count, setCount] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get("http://localhost:8080/adopt/counts")
+      .then((response) => {
+        setCount(response.data); // 페이지네이션을 사용할 경우에는 data.content로 받아야합니다.
+      })
+      .catch((error) => {
+        console.error("정보 가져오기 실패", error);
+      });
+  }, []);
+
+  return (
+    <React.Fragment>
+      <Title>입양 신청 현황</Title>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead></TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell sx={{ fontSize: "16px" }}>입양신청</TableCell>
+              <TableCell
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "18px",
+                }}
+              >
+                {count.totalCount}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell
+                sx={{
+                  fontSize: "16px",
+                }}
+              >
+                대기중
+              </TableCell>
+              <TableCell
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "18px",
+                }}
+              >
+                {count.waitingCount}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell
+                sx={{
+                  fontSize: "16px",
+                }}
+              >
+                입양완료
+              </TableCell>
+              <TableCell
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "18px",
+                }}
+              >
+                {count.successCount}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell
+                sx={{
+                  fontSize: "16px",
+                }}
+              >
+                입양반려
+              </TableCell>
+              <TableCell
+                style={{
+                  fontWeight: "bold",
+                  fontSize: "18px",
+                }}
+              >
+                {count.failCount}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Typography color="text.secondary" sx={{ flex: 1 }}></Typography>
+      <div style={{ height: "20px", textAlign: "right" }}>
+        <Link to={ADMIN.ADOPT}>입양 관리 이동</Link>
+      </div>
+    </React.Fragment>
+  );
+};
+
+export default Adopt;

--- a/src/pages/Admin/Dashboard/Board.js
+++ b/src/pages/Admin/Dashboard/Board.js
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from "react";
+import { ADMIN } from "../../../constants/PageURL";
+import { Link } from "react-router-dom";
+import { Box, Typography, Grid, Paper } from "@mui/material";
+import axios from "axios";
+
+const Board = () => {
+  const [adoptCount, setAdoptCount] = useState(0);
+  const [missingCount, setMissingCount] = useState(0);
+  const [findCount, setFindCount] = useState(0);
+  const [freeCount, setFreeCount] = useState(0);
+  const [fleaCount, setFleaCount] = useState(0);
+  const [volunteerCount, setVolunteerCount] = useState(0);
+  const [volunteerReviewCount, setVolunteerReviewCount] = useState(0);
+
+  const boardData = [
+    { name: "입양후기 게시판", count: adoptCount },
+    { name: "실종동물 게시판", count: missingCount },
+    { name: "목격제보 게시판", count: findCount },
+    { name: "자유게시판", count: freeCount },
+    { name: "매매장터", count: fleaCount },
+    { name: "봉사 게시판", count: volunteerCount },
+    { name: "봉사후기 게시판", count: volunteerReviewCount },
+  ];
+
+  useEffect(() => {
+    Promise.all([
+      axios.get("/board/review/count"),
+      axios.get("/board/missing/count"),
+      axios.get("/board/find/count"),
+      axios.get("/board/free/count"),
+      axios.get("/board/flea/count"),
+      axios.get("/board/volunteer/count"),
+      axios.get("/donate/volunteer/review/count"),
+    ])
+      .then(
+        ([
+          adoptRes,
+          missingRes,
+          findRes,
+          freeRes,
+          fleaRes,
+          volunteerRes,
+          volunteerReviewRes,
+        ]) => {
+          setAdoptCount(adoptRes.data);
+          setMissingCount(missingRes.data);
+          setFindCount(findRes.data);
+          setFreeCount(freeRes.data);
+          setFleaCount(fleaRes.data);
+          setVolunteerCount(volunteerRes.data);
+          setVolunteerReviewCount(volunteerReviewRes.data);
+        }
+      )
+      .catch((error) => {
+        console.error("axios 오류 : ", error);
+      });
+  }, []);
+
+  return (
+    <React.Fragment>
+      <Typography variant="h6" component="div" color="primary" sx={{ mb: 2 }}>
+        게시판 현황
+      </Typography>
+
+      <Grid container spacing={2}>
+        {boardData.map((board) => (
+          <Grid item xs={12} sm={6} md={4} lg={3} key={board.name}>
+            <Paper
+              sx={{
+                p: 2,
+                display: "flex",
+                flexDirection: "column",
+                height: 100,
+                alignItems: "center",
+              }}
+            >
+              <Typography variant="h7" sx={{ fontWeight: "bold" }}>
+                {board.name}
+              </Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="body2" color="text.primary">
+                총 게시글 수
+              </Typography>
+              <Typography
+                variant="h6"
+                color="text.primary"
+                sx={{ fontWeight: "bold" }}
+              >
+                {board.count}
+              </Typography>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+
+      <Box textAlign="right" mt={3}>
+        <Link to={ADMIN.BOARD}>게시판 관리 이동</Link>
+      </Box>
+    </React.Fragment>
+  );
+};
+
+export default Board;

--- a/src/pages/Admin/Dashboard/Deposits.js
+++ b/src/pages/Admin/Dashboard/Deposits.js
@@ -1,27 +1,30 @@
-import * as React from "react";
+import React, { useState, useEffect } from "react";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import Title from "./Title";
-
-function preventDefault(event) {
-  event.preventDefault();
-}
+import dayjs from "dayjs";
+import "dayjs/locale/ko";
+import axios from "axios";
 
 export default function Deposits() {
+  const formatCurrency = (number) => {
+    return number.toLocaleString("ko-KR", { currency: "KRW" }) + "원";
+  };
+
   return (
     <React.Fragment>
-      <Title>Recent Deposits</Title>
+      <Title>누적 판매금</Title>
       <Typography component="p" variant="h4">
-        $3,024.00
+        {formatCurrency(447220)}
       </Typography>
-      <Typography color="text.secondary" sx={{ flex: 1 }}>
-        on 15 월요일, 2019
+      <Typography
+        color="text.secondary"
+        sx={{ flex: 1 }}
+        style={{ marginTop: "16px" }}
+      >
+        {dayjs().locale("ko").format("YYYY-MM-DD dddd")}
       </Typography>
-      <div>
-        <Link color="primary" href="#" onClick={preventDefault}>
-          View balance
-        </Link>
-      </div>
+      <div></div>
     </React.Fragment>
   );
 }

--- a/src/pages/Admin/Dashboard/DonationChart.js
+++ b/src/pages/Admin/Dashboard/DonationChart.js
@@ -5,7 +5,6 @@ import {
   Line,
   XAxis,
   YAxis,
-  Label,
   ResponsiveContainer,
   Legend,
   BarChart,
@@ -21,40 +20,6 @@ import MenuItem from "@mui/material/MenuItem";
 import { ADMIN } from "../../../constants/PageURL";
 import { Link } from "react-router-dom";
 const MAX_DISPLAYED_DAILY_DATA = 31;
-
-// const data = [
-//   { date: "2023-05-01", total: 50000, member: 30000, nonMember: 20000 },
-//   { date: "2023-05-02", total: 70000, member: 40000, nonMember: 30000 },
-//   { date: "2023-05-03", total: 0, member: 0, nonMember: 0 },
-//   { date: "2023-05-04", total: 110000, member: 60000, nonMember: 50000 },
-//   { date: "2023-05-05", total: 130000, member: 70000, nonMember: 60000 },
-//   //   { date: "2023-05-06", total: 150000, member: 80000, nonMember: 70000 },
-//   //   { date: "2023-05-07", total: 170000, member: 90000, nonMember: 80000 },
-//   //   { date: "2023-05-08", total: 190000, member: 100000, nonMember: 90000 },
-//   //   { date: "2023-05-09", total: 210000, member: 110000, nonMember: 100000 },
-//   //   { date: "2023-05-10", total: 230000, member: 120000, nonMember: 110000 },
-//   //   { date: "2023-05-11", total: 250000, member: 130000, nonMember: 120000 },
-//   //   { date: "2023-05-12", total: 270000, member: 140000, nonMember: 130000 },
-//   //   { date: "2023-05-13", total: 290000, member: 150000, nonMember: 140000 },
-//   //   { date: "2023-05-14", total: 310000, member: 160000, nonMember: 150000 },
-//   //   { date: "2023-05-15", total: 330000, member: 170000, nonMember: 160000 },
-//   //   { date: "2023-05-16", total: 350000, member: 180000, nonMember: 170000 },
-//   //   { date: "2023-05-17", total: 370000, member: 190000, nonMember: 180000 },
-//   //   { date: "2023-05-18", total: 390000, member: 200000, nonMember: 190000 },
-//   //   { date: "2023-05-19", total: 410000, member: 210000, nonMember: 200000 },
-//   //   { date: "2023-05-20", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-21", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-22", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-23", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-24", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-25", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-26", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-27", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-28", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-29", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-30", total: 50000, member: 20000, nonMember: 30000 },
-//   //   { date: "2023-05-31", total: 50000, member: 20000, nonMember: 30000 },
-// ];
 
 const groupByMonth = (data) => {
   const groupedData = data.reduce((result, item) => {
@@ -247,7 +212,12 @@ const DonationChart = () => {
 
   return (
     <div>
-      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+      <Typography
+        variant="h6"
+        component="div"
+        color="primary"
+        style={{ marginBottom: "16px" }}
+      >
         기부 통계
       </Typography>
       <ToggleButtonGroup
@@ -285,13 +255,14 @@ const DonationChart = () => {
             년별
           </ToggleButton>
         </ToggleButtonGroup>
-      </div>
-      <div>
         {dataGroup === "daily" && (
           <Select
             value={selectedMonth}
             onChange={handleMonthChange}
             style={{ marginLeft: "16px" }}
+            sx={{
+              height: "45px",
+            }}
           >
             {Object.keys(groupByMonthAndDay(donationsData)).map((month) => (
               <MenuItem key={month} value={month}>
@@ -301,6 +272,7 @@ const DonationChart = () => {
           </Select>
         )}
       </div>
+
       <ResponsiveContainer width="100%" height={300}>
         <LineChart
           data={getChartData()}

--- a/src/pages/Admin/Dashboard/Member.js
+++ b/src/pages/Admin/Dashboard/Member.js
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -9,31 +9,7 @@ import Typography from "@mui/material/Typography";
 import { Avatar } from "@mui/material";
 import styled from "styled-components";
 import { ADMIN } from "../../../constants/PageURL";
-
-// Generate Order Data
-function createData(
-  memberNum,
-  memberId,
-  memberNickName,
-  memberEmail,
-  memberName,
-  memberGender,
-  memberBirth,
-  memberRole,
-  memberImg
-) {
-  return {
-    memberNum,
-    memberId,
-    memberNickName,
-    memberEmail,
-    memberName,
-    memberGender,
-    memberBirth,
-    memberRole,
-    memberImg,
-  };
-}
+import axios from "axios";
 
 const UserImg = styled(Avatar)`
   && {
@@ -45,72 +21,33 @@ const UserImg = styled(Avatar)`
   }
 `;
 
-const rows = [
-  createData(
-    1,
-    "admin1234",
-    "관리자",
-    "admin1@test.com",
-    "관리자",
-    "male",
-    "2000-01-01",
-    "Admin",
-    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/8f230276-3448-4a42-b3fa-8bac6dc06e83.png"
-  ),
-  createData(
-    2,
-    "test1234",
-    "닉네임1",
-    "test1@test.com",
-    "홍길동",
-    "male",
-    "2000-01-01",
-    "User",
-    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/5a395426-5d25-45b4-80e1-1ca846e1b5fc.png"
-  ),
-  createData(
-    3,
-    "test1235",
-    "닉네임2",
-    "test2@test.com",
-    "김길동",
-    "male",
-    "2000-01-01",
-    "User",
-    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/66336982-ecdb-44fe-9488-1d8f7a777bfa.png"
-  ),
-  createData(
-    4,
-    "test1236",
-    "닉네임3",
-    "test1@test.com",
-    "이길동",
-    "male",
-    "2000-01-01",
-    "User",
-    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/efe36b62-5e96-4c5b-8ce7-064bc0ca6f95.png"
-  ),
-  createData(
-    5,
-    "test1237",
-    "닉네임4",
-    "test1@test.com",
-    "박길동",
-    "male",
-    "2000-01-01",
-    "User",
-    "https://taemin-testbucket.s3.ap-northeast-2.amazonaws.com/petmily/2d014257-7fc4-4b7a-ae2e-b554d7c3f464.png"
-  ),
-];
-
-function preventDefault(event) {
-  event.preventDefault();
-}
-
 export default function Members() {
+  const [members, setMembers] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get("/members", {
+        params: {
+          page: 0,
+          size: 5,
+        },
+      })
+      .then((response) => {
+        setMembers(response.data.content); // 페이지네이션을 사용할 경우에는 data.content로 받아야합니다.
+      })
+      .catch((error) => {
+        console.error("There was an error!", error);
+      });
+  }, []);
+
   return (
     <React.Fragment>
-      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+      <Typography
+        variant="h6"
+        component="div"
+        color="primary"
+        style={{ marginBottom: "16px" }}
+      >
         회원
       </Typography>
       <Table size="small">
@@ -127,18 +64,18 @@ export default function Members() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map((row) => (
-            <TableRow key={row.id}>
+          {members.map((member) => (
+            <TableRow key={member.memberNum}>
               <TableCell>
-                <UserImg src={row.memberImg} />
+                <UserImg src={member.memberImg} />
               </TableCell>
-              <TableCell>{row.memberId}</TableCell>
-              <TableCell>{row.memberNickName}</TableCell>
-              <TableCell>{row.memberEmail}</TableCell>
-              <TableCell>{row.memberName}</TableCell>
-              <TableCell>{row.memberGender}</TableCell>
-              <TableCell>{row.memberBirth}</TableCell>
-              <TableCell align="right">{row.memberRole}</TableCell>
+              <TableCell>{member.memberId}</TableCell>
+              <TableCell>{member.memberNickname}</TableCell>
+              <TableCell>{member.memberEmail}</TableCell>
+              <TableCell>{member.memberName}</TableCell>
+              <TableCell>{member.memberGender}</TableCell>
+              <TableCell>{member.memberBirth}</TableCell>
+              <TableCell align="right">{member.memberRole}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/pages/Admin/Dashboard/OrderChart.js
+++ b/src/pages/Admin/Dashboard/OrderChart.js
@@ -13,6 +13,8 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Typography from "@mui/material/Typography";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
+import { ADMIN } from "../../../constants/PageURL";
+import { Link } from "react-router-dom";
 
 const dummyData = [
   { date: "2023-01-01", quantity: 5, cost: 15000 },
@@ -180,7 +182,12 @@ const OrderChart = () => {
 
   return (
     <div>
-      <Typography variant="h6" component="div" style={{ marginBottom: "16px" }}>
+      <Typography
+        variant="h6"
+        component="div"
+        color="primary"
+        style={{ marginBottom: "16px" }}
+      >
         주문 통계
       </Typography>
       <ToggleButtonGroup
@@ -215,13 +222,14 @@ const OrderChart = () => {
             년별
           </ToggleButton>
         </ToggleButtonGroup>
-      </div>
-      {period === "day" && (
-        <div>
+        {period === "day" && (
           <Select
             value={selectedMonth}
             onChange={handleMonthChange}
             style={{ marginLeft: "16px" }}
+            sx={{
+              height: "45px",
+            }}
           >
             {getMonths().map((month) => (
               <MenuItem key={month} value={month}>
@@ -229,8 +237,9 @@ const OrderChart = () => {
               </MenuItem>
             ))}
           </Select>
-        </div>
-      )}
+        )}
+      </div>
+
       <ResponsiveContainer width="100%" height={300}>
         <AreaChart
           data={selectedMonth ? selectedData : aggregateData(dummyData, period)}
@@ -253,7 +262,9 @@ const OrderChart = () => {
           />
         </AreaChart>
       </ResponsiveContainer>
-      <div style={{ marginTop: "80px" }} />
+      <div style={{ textAlign: "right", marginTop: "30px" }}>
+        <Link to={ADMIN.ORDER}>주문 관리 이동</Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/Admin/Donation/AdminDonation.js
+++ b/src/pages/Admin/Donation/AdminDonation.js
@@ -3,7 +3,11 @@ import axios from "axios";
 import * as S from "./AdminDonation.styled";
 import LoadingPage from "../../../components/Loading/LoadingPage";
 import VolunteerPagination from "../../../components/Support/Volunteer/VolunteerPagination";
+import Container from "@mui/material/Container";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import Paper from "@mui/material/Paper";
 
+const defaultTheme = createTheme();
 const AdminDonation = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [memberDonaions, setMemberDonations] = useState({
@@ -15,6 +19,8 @@ const AdminDonation = () => {
     totalPages: 0,
   }); //비회원 기부내역
   const [totalCost, setTotalCost] = useState(0);
+  const [memberTotalCost, setMemberTotalCost] = useState(0);
+  const [nonMemberTotalCost, setNonMemberTotalCost] = useState(0);
   const [memberPage, setMemberPage] = useState(0);
   const [nonMemberPage, setNonMemberPage] = useState(0);
   const [size, setSize] = useState(10);
@@ -42,19 +48,31 @@ const AdminDonation = () => {
         },
       }),
       axios.get("/donate/total"),
+      axios.get("/donate/total/member"),
+      axios.get("/donate/total/non-member"),
     ])
-      .then(([memberRes, nonMemberRes, totalRes]) => {
-        setMemberDonations({
-          content: memberRes.data.content,
-          totalPages: memberRes.data.totalPages,
-        });
-        setNonMemberDonations({
-          content: nonMemberRes.data.content,
-          totalPages: nonMemberRes.data.totalPages,
-        });
-        setTotalCost(totalRes.data);
-        setIsLoading(false);
-      })
+      .then(
+        ([
+          memberRes,
+          nonMemberRes,
+          totalRes,
+          memberTotalRes,
+          nonMemberTotalRes,
+        ]) => {
+          setMemberDonations({
+            content: memberRes.data.content,
+            totalPages: memberRes.data.totalPages,
+          });
+          setNonMemberDonations({
+            content: nonMemberRes.data.content,
+            totalPages: nonMemberRes.data.totalPages,
+          });
+          setTotalCost(totalRes.data);
+          setMemberTotalCost(memberTotalRes.data);
+          setNonMemberTotalCost(nonMemberTotalRes.data);
+          setIsLoading(false);
+        }
+      )
       .catch((error) => {
         console.error("axios 오류 : ", error);
         setIsLoading(false);
@@ -80,87 +98,109 @@ const AdminDonation = () => {
     );
   } else {
     return (
-      <S.Container>
-        <S.TotalDonation>
-          누적 기부금 : {formatCurrency(totalCost)}
-        </S.TotalDonation>
+      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+        <Paper sx={{ p: 1, mb: 2 }}>
+          <S.TotalDonation>
+            누적 기부금 : {formatCurrency(totalCost)}
+          </S.TotalDonation>
+        </Paper>
         <S.RecentDonations>
-          <S.DonationColumn>
-            <S.TableTitle>비회원 기부 내역</S.TableTitle>
-            <S.Table>
-              <thead>
-                <S.TableRow>
-                  <S.TableHeader>기부날짜</S.TableHeader>
-                  <S.TableHeader>기부명</S.TableHeader>
-                  <S.TableHeader>기부자</S.TableHeader>
-                  <S.TableHeader>기부자 전화번호</S.TableHeader>
-                  <S.TableHeader>기부자 이메일</S.TableHeader>
-                  <S.TableHeader>기부 금액</S.TableHeader>
-                </S.TableRow>
-              </thead>
-              <tbody>
-                {nonMemberDonaions.content.map((donation, index) => (
-                  <S.TableRow key={index}>
-                    <S.TableData>
-                      {formatDate(donation.donationDate)}
-                    </S.TableData>
-                    <S.TableData>{donation.donationDonor}</S.TableData>
-                    <S.TableData>{donation.donationName}님</S.TableData>
-                    <S.TableData>{donation.donationTel}</S.TableData>
-                    <S.TableData>{donation.donationEmail}</S.TableData>
-                    <S.TableData>
-                      {formatCurrency(donation.donationCost)}
-                    </S.TableData>
+          <Paper
+            sx={{
+              width: "100%",
+              mb: 2,
+            }}
+          >
+            <S.DonationColumn>
+              <S.TableTitle>비회원 기부 내역</S.TableTitle>
+              <div>
+                비회원 누적 기부금 : <b>{formatCurrency(nonMemberTotalCost)}</b>
+              </div>
+              <S.Table>
+                <thead>
+                  <S.TableRow>
+                    <S.TableHeader>기부날짜</S.TableHeader>
+                    <S.TableHeader>기부명</S.TableHeader>
+                    <S.TableHeader>기부자</S.TableHeader>
+                    <S.TableHeader>기부자 전화번호</S.TableHeader>
+                    <S.TableHeader>기부자 이메일</S.TableHeader>
+                    <S.TableHeader>기부 금액</S.TableHeader>
                   </S.TableRow>
-                ))}
-              </tbody>
-            </S.Table>
-            <VolunteerPagination
-              count={nonMemberDonaions.totalPages}
-              page={nonMemberPage + 1}
-              onChange={handleNonMemberChange}
-            />
-          </S.DonationColumn>
+                </thead>
+                <tbody>
+                  {nonMemberDonaions.content.map((donation, index) => (
+                    <S.TableRow key={index}>
+                      <S.TableData>
+                        {formatDate(donation.donationDate)}
+                      </S.TableData>
+                      <S.TableData>{donation.donationDonor}</S.TableData>
+                      <S.TableData>{donation.donationName}님</S.TableData>
+                      <S.TableData>{donation.donationTel}</S.TableData>
+                      <S.TableData>{donation.donationEmail}</S.TableData>
+                      <S.TableData>
+                        {formatCurrency(donation.donationCost)}
+                      </S.TableData>
+                    </S.TableRow>
+                  ))}
+                </tbody>
+              </S.Table>
+              <VolunteerPagination
+                count={nonMemberDonaions.totalPages}
+                page={nonMemberPage + 1}
+                onChange={handleNonMemberChange}
+              />
+            </S.DonationColumn>
+          </Paper>
         </S.RecentDonations>
+
         <S.RecentDonations>
-          <S.DonationColumn>
-            <S.TableTitle>회원 기부 내역</S.TableTitle>
-            <S.Table>
-              <thead>
-                <S.TableRow>
-                  <S.TableHeader>기부날짜</S.TableHeader>
-                  <S.TableHeader>기부명</S.TableHeader>
-                  <S.TableHeader>기부자</S.TableHeader>
-                  <S.TableHeader>기부자 전화번호</S.TableHeader>
-                  <S.TableHeader>기부자 이메일</S.TableHeader>
-                  <S.TableHeader>기부 금액</S.TableHeader>
-                </S.TableRow>
-              </thead>
-              <tbody>
-                {memberDonaions.content.map((donation, index) => (
-                  <S.TableRow key={index}>
-                    <S.TableData>
-                      {formatDate(donation.donationDate)}
-                    </S.TableData>
-                    <S.TableData>{donation.donationDonor}</S.TableData>
-                    <S.TableData>{donation.donationName}님</S.TableData>
-                    <S.TableData>{donation.donationTel}</S.TableData>
-                    <S.TableData>{donation.donationEmail}</S.TableData>
-                    <S.TableData>
-                      {formatCurrency(donation.donationCost)}
-                    </S.TableData>
+          <Paper
+            sx={{
+              width: "100%",
+            }}
+          >
+            <S.DonationColumn>
+              <S.TableTitle>회원 기부 내역</S.TableTitle>
+              <div>
+                회원 누적 기부금 : <b>{formatCurrency(memberTotalCost)}</b>
+              </div>
+              <S.Table>
+                <thead>
+                  <S.TableRow>
+                    <S.TableHeader>기부날짜</S.TableHeader>
+                    <S.TableHeader>기부명</S.TableHeader>
+                    <S.TableHeader>기부자</S.TableHeader>
+                    <S.TableHeader>기부자 전화번호</S.TableHeader>
+                    <S.TableHeader>기부자 이메일</S.TableHeader>
+                    <S.TableHeader>기부 금액</S.TableHeader>
                   </S.TableRow>
-                ))}
-              </tbody>
-            </S.Table>
-            <VolunteerPagination
-              count={memberDonaions.totalPages}
-              page={memberPage + 1}
-              onChange={handleMemberChange}
-            />
-          </S.DonationColumn>
+                </thead>
+                <tbody>
+                  {memberDonaions.content.map((donation, index) => (
+                    <S.TableRow key={index}>
+                      <S.TableData>
+                        {formatDate(donation.donationDate)}
+                      </S.TableData>
+                      <S.TableData>{donation.donationDonor}</S.TableData>
+                      <S.TableData>{donation.donationName}님</S.TableData>
+                      <S.TableData>{donation.donationTel}</S.TableData>
+                      <S.TableData>{donation.donationEmail}</S.TableData>
+                      <S.TableData>
+                        {formatCurrency(donation.donationCost)}
+                      </S.TableData>
+                    </S.TableRow>
+                  ))}
+                </tbody>
+              </S.Table>
+              <VolunteerPagination
+                count={memberDonaions.totalPages}
+                page={memberPage + 1}
+                onChange={handleMemberChange}
+              />
+            </S.DonationColumn>
+          </Paper>
         </S.RecentDonations>
-      </S.Container>
+      </Container>
     );
   }
 };

--- a/src/pages/Admin/Donation/AdminDonation.styled.js
+++ b/src/pages/Admin/Donation/AdminDonation.styled.js
@@ -9,7 +9,7 @@ const Container = styled.div`
 
 const TotalDonation = styled.p`
   text-align: right;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: bold;
   margin: 20px 0;
 `;
@@ -23,6 +23,7 @@ const RecentDonations = styled.div`
 const DonationColumn = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 20px;
   width: 100%;
   margin-bottom: 40px;
@@ -37,7 +38,7 @@ const TableTitle = styled.div`
 `;
 
 const Table = styled.table`
-  width: 100%;
+  width: 90%;
   text-align: left;
   border-collapse: collapse;
 `;

--- a/src/pages/Admin/Member/AdminMember.js
+++ b/src/pages/Admin/Member/AdminMember.js
@@ -1,5 +1,241 @@
+import {
+  Box,
+  Button,
+  Container,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Select,
+  MenuItem,
+  ThemeProvider,
+} from "@mui/material";
+import { CustomTheme } from "../../../assets/Theme/CustomTheme";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { Avatar } from "@mui/material";
+import styled from "styled-components";
+import LoadingPage from "../../../components/Loading/LoadingPage";
+
+const UserImg = styled(Avatar)`
+  && {
+    margin-right: 8px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-left: 10px;
+  }
+`;
+
 const AdminMember = () => {
-  return <div>AdminMember</div>;
+  const [members, setMembers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [totalMembers, setTotalMembers] = useState(0);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      setIsLoading(true);
+      const response = await axios.get("/members", {
+        params: {
+          page: page,
+          size: rowsPerPage,
+        },
+      });
+      setMembers(response.data.content);
+      const memberCountResponse = await axios.get("/members/count");
+      setTotalMembers(memberCountResponse.data);
+      setIsLoading(false);
+    };
+    fetchMembers();
+  }, [page, rowsPerPage]);
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleDeleteMember = async (memberNum) => {
+    try {
+      await axios.delete(`/members/${memberNum}`);
+      // 회원 데이터 삭제 후 목록을 다시 불러옴
+      const response = await axios.get("/members", {
+        params: {
+          page: page,
+          size: rowsPerPage,
+        },
+      });
+      setMembers(response.data.content);
+      const memberCountResponse = await axios.get("/members/count");
+      setTotalMembers(memberCountResponse.data);
+    } catch (error) {
+      console.error("회원 삭제 실패:", error);
+    }
+  };
+
+  const handleDeleteButtonClick = (memberNum) => {
+    if (window.confirm("정말로 회원을 삭제하시겠습니까?")) {
+      handleDeleteMember(memberNum);
+      alert("회원 삭제가 완료되었습니다.");
+    }
+  };
+
+  const handleRoleChange = (memberNum, newRole) => {
+    if (window.confirm("멤버 권한을 수정하시겠습니까?")) {
+      axios
+        .put(`/updateRole/${memberNum}`, { memberRole: newRole })
+        .then((response) => {
+          window.alert("권한이 수정 되었습니다");
+          return axios.get("/members", {
+            //수정 후 다시 데이터 가져옴.
+            params: {
+              page: page,
+              size: rowsPerPage,
+            },
+          });
+        })
+        .then((response) => {
+          setMembers(response.data.content);
+        })
+        .catch((error) => {
+          console.error("There was an error!", error);
+          window.alert("수정 실패");
+        });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div>
+        <LoadingPage />
+      </div>
+    );
+  } else {
+    return (
+      <ThemeProvider theme={CustomTheme}>
+        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+          <Paper sx={{ p: 1, mb: 2 }}>
+            <Box
+              display={"flex"}
+              justifyContent={"space-between"}
+              mt={2}
+              mb={2}
+            >
+              <Box display={"flex"} justifyContent={"flex-end"}>
+                총 회원수 : {totalMembers} 명
+              </Box>
+            </Box>
+          </Paper>
+          <Paper>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    대표이미지
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    ID
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    닉네임
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    Email
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    이름
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    성별
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    생년월일
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    유저 권한
+                  </TableCell>
+                  <TableCell align="center" sx={{ fontWeight: "bold" }}>
+                    관리
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {members.map((member) => {
+                  return (
+                    <TableRow key={member.memberNum}>
+                      <TableCell>
+                        {<UserImg src={member.memberImg} />}{" "}
+                      </TableCell>
+                      <TableCell align="center">{member.memberId}</TableCell>
+                      <TableCell align="center">
+                        {member.memberNickname}
+                      </TableCell>
+                      <TableCell align="center">{member.memberEmail}</TableCell>
+                      <TableCell align="center">{member.memberName}</TableCell>
+                      <TableCell align="center">
+                        {member.memberGender}
+                      </TableCell>
+                      <TableCell align="center">{member.memberBirth}</TableCell>
+                      <TableCell align="center">
+                        <Select
+                          sx={{
+                            fontSize: "13px",
+                            width: "100px",
+                            height: "40px",
+                          }}
+                          value={member.memberRole}
+                          onChange={(e) =>
+                            handleRoleChange(member.memberNum, e.target.value)
+                          }
+                        >
+                          <MenuItem sx={{ fontSize: "13px" }} value={"Admin"}>
+                            Admin
+                          </MenuItem>
+                          <MenuItem sx={{ fontSize: "13px" }} value={"User"}>
+                            User
+                          </MenuItem>
+                        </Select>
+                      </TableCell>
+                      <TableCell align="center">
+                        <Button
+                          variant="contained"
+                          color="ff8282"
+                          size="small"
+                          onClick={() =>
+                            handleDeleteButtonClick(member.memberNum)
+                          }
+                        >
+                          삭제
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+            <Box sx={{ p: 2, display: "flex", justifyContent: "right" }}>
+              <TablePagination
+                component="div"
+                count={totalMembers}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+              />
+            </Box>
+          </Paper>
+        </Container>
+      </ThemeProvider>
+    );
+  }
 };
 
 export default AdminMember;

--- a/src/pages/Support/Donate.js
+++ b/src/pages/Support/Donate.js
@@ -16,6 +16,8 @@ const Donate = () => {
   const [memberDonaions, setMemberDonations] = useState([]); //회원 기부내역
   const [nonMemberDonaions, setNonMemberDonations] = useState([]); //비회원 기부내역
   const [totalCost, setTotalCost] = useState(0);
+  const [memberTotalCost, setMemberTotalCost] = useState(0);
+  const [nonMemberTotalCost, setNonMemberTotalCost] = useState(0);
 
   useEffect(() => {
     Promise.all([
@@ -32,13 +34,25 @@ const Donate = () => {
         },
       }),
       axios.get("/donate/total"),
+      axios.get("/donate/total/member"),
+      axios.get("/donate/total/non-member"),
     ])
-      .then(([memberRes, nonMemberRes, totalRes]) => {
-        setMemberDonations(memberRes.data.content);
-        setNonMemberDonations(nonMemberRes.data.content);
-        setTotalCost(totalRes.data);
-        setIsLoading(false);
-      })
+      .then(
+        ([
+          memberRes,
+          nonMemberRes,
+          totalRes,
+          memberTotalRes,
+          nonMemberTotalRes,
+        ]) => {
+          setMemberDonations(memberRes.data.content);
+          setNonMemberDonations(nonMemberRes.data.content);
+          setTotalCost(totalRes.data);
+          setMemberTotalCost(memberTotalRes.data);
+          setNonMemberTotalCost(nonMemberTotalRes.data);
+          setIsLoading(false);
+        }
+      )
       .catch((error) => {
         console.error("axios 오류 : ", error);
         setIsLoading(false);
@@ -68,6 +82,9 @@ const Donate = () => {
         <S.RecentDonations>
           <S.DonationColumn>
             <S.TableTitle>비회원 기부 내역</S.TableTitle>
+            <div style={{ textAlign: "center" }}>
+              비회원 누적 기부금 : <b>{formatCurrency(nonMemberTotalCost)}</b>
+            </div>
             <S.Table>
               <thead>
                 <S.TableRow>
@@ -95,6 +112,9 @@ const Donate = () => {
           </S.DonationColumn>
           <S.DonationColumn>
             <S.TableTitle>회원 기부 내역</S.TableTitle>
+            <div style={{ textAlign: "center" }}>
+              회원 누적 기부금 : <b>{formatCurrency(memberTotalCost)}</b>
+            </div>
             <S.Table>
               <thead>
                 <S.TableRow>


### PR DESCRIPTION
# 관리자 페이지, 후원 페이지 작업 내역
## 후원 페이지
- [x] 기부 페이지 회원, 비회원 누적 기부금 표시

## 관리자 페이지
- [x] 관리자 대시보드 기부 통계 일별 select 위치 변경
- [x] 관리자 대시보드 회원 목록 백엔드 연동
- [x] 관리자 대시보드 주문 통계 select 제목디자인 변경, Link 추가  
- [x] 회원 관리 페이지 폼 작성, 백엔드 연동, 권한 변경 회원 삭제 기능 구현
- [x] 기부 관리 페이지 회원, 비회원 누적 기부액 표시
- [x] 주문 누적 판매금 컴포넌트 추가 및 관리자 대시보드에 배치
- [x] 입양 신청 상태 컴포넌트 추가 및 백엔드 연동, 관리자 대시보드 배치 
- [x] 게시글 현황 (총 게시글수) 컴포넌트 추가 및 백엔드 연동, 관리자 대시보드 배치 
- [x] 수정버튼과 삭제버튼 위치 교환.